### PR TITLE
Add prefix key + edge-case fixes + comments

### DIFF
--- a/docker/python-s3-zip/docker-compose.yml
+++ b/docker/python-s3-zip/docker-compose.yml
@@ -53,7 +53,8 @@ services:
                         "Endpoint": "http://toxiproxy:9000",
                         "VirtualAddressing": false,
                         "EnableCompression": false,
-                        "LocalStorageMaxSizeMB": 3000
+                        "LocalStorageMaxSizeMB": 3000,
+                        "PrefixKey": "orthanc-zips"
                     },
                     "Python": {
                         "AllowThreads": true

--- a/docker/python-s3-zip/plugin/helpers.py
+++ b/docker/python-s3-zip/plugin/helpers.py
@@ -9,7 +9,9 @@ logger = get_logger(__name__)
 class Helpers:
 
     @classmethod
-    # note: this returns a hash that is not necessarily identical to the Orthanc series_id but that has the same "uniqueness" since it is based on the same inputs
+    # note: this returns a hash that is not necessarily identical to the
+    # Orthanc series_id but that has the same "uniqueness" since it is based
+    # on the same inputs
     def get_series_hash(cls, dicom_instance: orthanc.DicomInstance) -> str:
         tags = json.loads(dicom_instance.GetInstanceSimplifiedJson())
 
@@ -27,5 +29,5 @@ class Helpers:
                      series_hash=series_hash)
 
         return series_hash
-        
+
 

--- a/docker/python-s3-zip/plugin/local_storage.py
+++ b/docker/python-s3-zip/plugin/local_storage.py
@@ -4,7 +4,7 @@ import threading
 import subprocess
 import queue
 import shutil
-from typing import Tuple, Optional
+from typing import Callable, Tuple, Optional
 from local_storage_interface import LocalStorageInterface
 from collections import deque
 from s3zip_logging import get_logger
@@ -21,11 +21,13 @@ class LocalStorage(LocalStorageInterface):
     _block_size: int
     _lock: threading.RLock
     _folder_stats: queue.PriorityQueue
+    _is_folder_safe_to_evict: Optional[Callable[[str], bool]]
 
     def __init__(self, root: str, max_size_mb: int):
         self._root = root
         self._max_size = max_size_mb * 1024 * 1024
         self._lock = threading.RLock()
+        self._is_folder_safe_to_evict = None
 
         self._update_local_storage_stats()
 
@@ -33,6 +35,15 @@ class LocalStorage(LocalStorageInterface):
                      root=root,
                      max_size_mb=max_size_mb,
                      max_size_bytes=self._max_size)
+
+    def set_eviction_guard(self, is_folder_safe_to_evict: callable):
+        """
+        - Set a callback that determines if a local series folder is safe to evict.
+        - The callback receives the folder name (not the full path) and 
+          must return True if the folder's data has been safely backed up to S3.
+        - If this callback is not set, all folders are considered safe to evict.
+        """
+        self._is_folder_safe_to_evict = is_folder_safe_to_evict
 
     def _update_local_storage_stats(self):
         with self._lock:
@@ -64,13 +75,52 @@ class LocalStorage(LocalStorageInterface):
 
             self._update_local_storage_stats()
 
-            # reclaim space
+            # Reclaim space -- evict oldest folders first, but protect folders
+            # whose data has not yet been safely backed up to S3.
+            # This can be useful if the plugin receives a burst of uploads that
+            # exceed the local storage capacity, but the S3 upload process is
+            # still catching up
+            skipped = []
             while estimated_disk_size > self._available_size and not self._folder_stats.empty():
-                _, path, folder_size = self._folder_stats.get()
+                entry = self._folder_stats.get()
+                _, path, folder_size = entry
+
+                folder_name = os.path.basename(path)
+
+                if self._is_folder_safe_to_evict is not None:
+                    try:
+                        safe = self._is_folder_safe_to_evict(folder_name)
+                    except Exception as e:
+                        logger.warning("eviction guard check failed, skipping folder",
+                                       folder=folder_name, error=str(e))
+                        safe = False
+
+                    if not safe:
+                        logger.info(
+                            "LocalStorage: skipping eviction of folder not yet on S3",
+                            folder=folder_name, folder_size=folder_size)
+                        skipped.append(entry)
+                        continue
 
                 orthanc.LogInfo(f"LocalStorage: reclaiming space by deleting local folder '{path}'")
+
+                # TODO: handle errors here (e.g. if the file gets locked by
+                # another process, or if it is being deleted by someone trying
+                # to help! Unlikely but what can go wrong will go wrong...)
                 shutil.rmtree(path)
                 self._available_size += folder_size
+
+            # put skipped entries back
+            for entry in skipped:
+                self._folder_stats.put(entry)
+
+            if estimated_disk_size > self._available_size:
+                logger.warning(
+                    "LocalStorage: could not free enough space. "
+                    "Some folders are protected because they are not yet on S3.",
+                    needed=estimated_disk_size,
+                    available=self._available_size,
+                    protected_folders=len(skipped))
 
 
     def write_file(self, local_series_folder: str, uuid: str, content: bytes):
@@ -256,6 +306,10 @@ class LocalStorage(LocalStorageInterface):
             raise RuntimeError(f"Unsupported content type: {content_type}")
 
         return os.path.join(self._root, os.path.join(local_series_folder, uuid))
+
+    def get_folder_path(self, local_series_folder: str) -> str:
+        """Returns the full path for a series folder."""
+        return os.path.join(self._root, local_series_folder)
 
     def has_local_file(self, uuid: str, local_series_folder: str, content_type: orthanc.ContentType) -> bool:
         path = self.get_local_path(uuid=uuid,

--- a/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
+++ b/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
@@ -101,11 +101,12 @@ class LocalToS3ZipManager:
     _threads_should_stop: bool
     _zip_compression: int
 
-    def __init__(self, s3_client: S3Client, bucket_name: str, local_storage: LocalStorageInterface, enable_compression: bool, uncommitted_series_handler: UncommittedSeriesHandler):
+    def __init__(self, s3_client: S3Client, bucket_name: str, local_storage: LocalStorageInterface, enable_compression: bool, uncommitted_series_handler: UncommittedSeriesHandler, key_prefix: str = ""):
         self._s3_client = s3_client
         self._bucket_name = bucket_name
         self._local_storage = local_storage
         self._uncommitted_series_handler = uncommitted_series_handler
+        self._key_prefix = key_prefix.strip('/')
         if enable_compression:
             self._zip_compression = zipfile.ZIP_DEFLATED
         else:
@@ -118,7 +119,8 @@ class LocalToS3ZipManager:
         compression_name = "ZIP_DEFLATED" if enable_compression else "ZIP_STORED"
         logger.debug("LocalToS3ZipManager initialized",
                      bucket=bucket_name,
-                     compression=compression_name)
+                     compression=compression_name,
+                     key_prefix=self._key_prefix or "<none>")
 
 
     def start(self):
@@ -134,6 +136,8 @@ class LocalToS3ZipManager:
 
 
     def _get_series_s3_key(self, series_id: str) -> str:
+        if self._key_prefix:
+            return f"{self._key_prefix}/{series_id}.zip"
         return f"{series_id}.zip"
 
 

--- a/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
+++ b/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
@@ -295,6 +295,21 @@ class LocalToS3ZipManager:
             # At this point, the local storage does not need to keep the files stored locally but there is no need to notify it.
             # In the best scenario, the files will still be stored locally at the time we need it.
 
+            # Write a marker file so the LRU eviction guard knows this folder is safe to evict
+            if local_series_folder:
+                marker_path = os.path.join(
+                    self._local_storage.get_folder_path(local_series_folder),
+                    ".s3-uploaded"
+                )
+                try:
+                    with open(marker_path, "w") as f:
+                        f.write(s3_key)
+                    logger.debug("wrote S3 upload marker file",
+                                 series_id=series_id, marker_path=marker_path)
+                except Exception as e:
+                    logger.warning("failed to write S3 upload marker file",
+                                   series_id=series_id, error=str(e))
+
         duration_ms = int((time.monotonic() - t0) * 1000)
 
         self._uncommitted_series_handler.on_committed_series(series_id=series_id)

--- a/docker/python-s3-zip/plugin/s3_zip_storage.py
+++ b/docker/python-s3-zip/plugin/s3_zip_storage.py
@@ -19,12 +19,13 @@ class S3ZipStorage:
     _zip_manager: LocalToS3ZipManager
     _uncommitted_series_handler: UncommittedSeriesHandler
 
-    def __init__(self, temporary_folder_root: str, temp_folder_max_size_mb: int, s3_client: S3Client, bucket_name: str, enable_compression: bool):
+    def __init__(self, temporary_folder_root: str, temp_folder_max_size_mb: int, s3_client: S3Client, bucket_name: str, enable_compression: bool, key_prefix: str = ""):
         logger.debug("initializing S3ZipStorage",
                      temp_folder=temporary_folder_root,
                      max_size_mb=temp_folder_max_size_mb,
                      bucket=bucket_name,
-                     compression=enable_compression)
+                     compression=enable_compression,
+                     key_prefix=key_prefix or "<none>")
 
         self._uncommitted_series_handler = UncommittedSeriesHandler()
 
@@ -35,7 +36,8 @@ class S3ZipStorage:
                                                 bucket_name=bucket_name,
                                                 local_storage=self._local_storage,
                                                 enable_compression=enable_compression,
-                                                uncommitted_series_handler=self._uncommitted_series_handler)
+                                                uncommitted_series_handler=self._uncommitted_series_handler,
+                                                key_prefix=key_prefix)
 
         # Set up the eviction guard: a folder is safe to evict only if it has the
         # .s3-uploaded marker file written by the copy thread after a successful S3 upload.

--- a/docker/python-s3-zip/plugin/s3_zip_storage.py
+++ b/docker/python-s3-zip/plugin/s3_zip_storage.py
@@ -37,6 +37,14 @@ class S3ZipStorage:
                                                 enable_compression=enable_compression,
                                                 uncommitted_series_handler=self._uncommitted_series_handler)
 
+        # Set up the eviction guard: a folder is safe to evict only if it has the
+        # .s3-uploaded marker file written by the copy thread after a successful S3 upload.
+        def _is_folder_safe_to_evict(folder_name: str) -> bool:
+            marker_path = os.path.join(self._local_storage.get_folder_path(folder_name), ".s3-uploaded")
+            return os.path.exists(marker_path)
+
+        self._local_storage.set_eviction_guard(_is_folder_safe_to_evict)
+
         logger.debug("S3ZipStorage initialized")
 
     def start(self):
@@ -134,17 +142,44 @@ class S3ZipStorage:
         logger.debug("local_storage.has_local_file() returned", uuid=uuid, has_local=has_local)
 
         if not has_local:
+            s3_zip_key = cd.s3_zip_key
+
+            if s3_zip_key is None:
+                # The custom data says "local" but the file is gone (pod restart with
+                # ephemeral storage, or LRU eviction before S3 upload).
+                # Try to recover by checking if a marker file left by the S3 copy thread
+                # tells us the S3 key.
+                marker_path = os.path.join(
+                    self._local_storage.get_folder_path(cd.local_series_folder),
+                    ".s3-uploaded"
+                )
+                if os.path.exists(marker_path):
+                    with open(marker_path, "r") as f:
+                        s3_zip_key = f.read().strip()
+                    logger.warning(
+                        "instance marked as local but file is gone; recovered S3 key from marker",
+                        uuid=uuid,
+                        s3_zip_key=s3_zip_key,
+                        local_series_folder=cd.local_series_folder)
+                else:
+                    logger.error(
+                        "instance marked as local but file is gone and no S3 key available. "
+                        "DATA LOSS: this instance cannot be retrieved.",
+                        uuid=uuid,
+                        local_series_folder=cd.local_series_folder)
+                    return orthanc.ErrorCode.UNKNOWN_RESOURCE, None
+
             logger.info("instance not in local cache, retrieving series from S3",
                         uuid=uuid,
-                        s3_zip_key=cd.s3_zip_key,
+                        s3_zip_key=s3_zip_key,
                         local_series_folder=cd.local_series_folder)
-            logger.debug("calling zip_manager.retrieve_zip_from_s3()", uuid=uuid, s3_zip_key=cd.s3_zip_key)
-            self._zip_manager.retrieve_zip_from_s3(s3_zip_key=cd.s3_zip_key,
+            logger.debug("calling zip_manager.retrieve_zip_from_s3()", uuid=uuid, s3_zip_key=s3_zip_key)
+            self._zip_manager.retrieve_zip_from_s3(s3_zip_key=s3_zip_key,
                                                    local_series_folder=cd.local_series_folder)
             logger.debug("zip_manager.retrieve_zip_from_s3() returned", uuid=uuid)
             logger.info("series retrieved from S3 into local cache",
                         uuid=uuid,
-                        s3_zip_key=cd.s3_zip_key)
+                        s3_zip_key=s3_zip_key)
         else:
             logger.debug("instance found in local cache",
                          uuid=uuid,

--- a/docker/python-s3-zip/plugin/s3_zip_storage_plugin.py
+++ b/docker/python-s3-zip/plugin/s3_zip_storage_plugin.py
@@ -257,7 +257,9 @@ def register_s3_zip_storage_plugin():
         logger.error("failed to access S3 bucket", bucket=bucket_name, error=str(e))
         raise RuntimeError(f"S3Zip: An Error happened while trying to access bucket '{bucket_name}': {e}.")
 
-    test_path = f"_test-access-rights-{uuid_module.uuid4()}"
+    _test_key_prefix = s3_zip_config.get("PrefixKey", "").strip('/')
+    _test_suffix = f"_test-access-rights-{uuid_module.uuid4()}"
+    test_path = f"{_test_key_prefix}/{_test_suffix}" if _test_key_prefix else _test_suffix
 
     try:
         logger.debug("testing WRITE access to S3 bucket", bucket=bucket_name, test_key=test_path)
@@ -308,11 +310,15 @@ def register_s3_zip_storage_plugin():
         max_local_storage_size_mb = 1024
     logger.debug("compression setting resolved", enable_compression=enable_compression)
 
+    key_prefix = s3_zip_config.get("PrefixKey", "").strip('/')
+    logger.debug("key prefix resolved", key_prefix=key_prefix or "<none>")
+
     storage_singleton = S3ZipStorage(temporary_folder_root=s3_temp_folder_root,
                                      temp_folder_max_size_mb=max_local_storage_size_mb,
                                      s3_client=s3_client,
                                      bucket_name=bucket_name,
-                                     enable_compression=enable_compression)
+                                     enable_compression=enable_compression,
+                                     key_prefix=key_prefix)
 
     logger.info("registering storage area callbacks with Orthanc (RegisterStorageArea3)")
     logger.debug("calling orthanc.RegisterStorageArea3()")
@@ -330,12 +336,13 @@ def register_s3_zip_storage_plugin():
                 bucket=bucket_name,
                 region=s3_zip_config.get("Region"),
                 temp_folder=s3_temp_folder_root,
-                compression=enable_compression)
+                compression=enable_compression,
+                key_prefix=key_prefix or "<none>")
 
     # Failsafe: bypass logging framework entirely so this is always visible
     print(f"[s3zip] storage plugin registered | bucket={bucket_name} "
           f"region={s3_zip_config.get('Region')} temp_folder={s3_temp_folder_root} "
-          f"compression={enable_compression}", file=sys.stderr)
+          f"compression={enable_compression} key_prefix={key_prefix or '<none>'}", file=sys.stderr)
 
 def on_new_series(series_id: str):
 

--- a/docker/python-s3-zip/plugin/s3zip_logging.py
+++ b/docker/python-s3-zip/plugin/s3zip_logging.py
@@ -29,8 +29,7 @@ from typing import Callable, Optional
 #
 # **Why this matters in Orthanc:**
 # The s3zip plugin runs inside Orthanc's Python plugin host, where
-# **other plugins load first**. In particular, `plugin_lib.config`
-# (from the `o8t_utility_plugin` package) likely calls `logging.basicConfig()`
+# **other plugins load first**. In particular, the caller uses `logging.basicConfig()`
 # during its own initialization. By the time the s3zip plugin initializes:
 #
 # 1.  The root logger already has a handler (configured by `plugin_lib.config`).
@@ -53,7 +52,7 @@ from typing import Callable, Optional
 # its own format, its own output stream --- regardless of what any other plugin
 # or the Orthanc host has already done to the root logger.
 #
-# **After `inject_logger_factory()` is called** (from `o8t_orthanc_plugin.py`),
+# **After `inject_logger_factory()` is called** by the calling application,
 # the s3zip-specific handler is removed and `propagate` is set to True so that
 # all s3zip messages flow through the root logger's JSON formatter instead.
 
@@ -112,7 +111,7 @@ def _ensure_s3zip_logging():
 def inject_logger_factory(factory: Callable[[str], logging.Logger]) -> None:
     """Switch s3zip loggers to use the shared root logger (JSON-formatted).
 
-    Call this from ``o8t_orthanc_plugin.py`` after importing the s3zip plugin
+    Call this from your application after importing the s3zip plugin
     and after ``plugin_lib.config`` has set up JSON logging on the root logger.
 
     Effect:

--- a/docker/python-s3-zip/test-scenario.py
+++ b/docker/python-s3-zip/test-scenario.py
@@ -89,7 +89,7 @@ def wait_until_zip_found_on_s3(series_id: str):
     found = False
     while not found:
         try:
-            s3_client.head_object(Bucket="zip-bucket", Key=f"{series_id}.zip")
+            s3_client.head_object(Bucket="zip-bucket", Key=f"orthanc-zips/{series_id}.zip")
             return
         except Exception as e:
             pass
@@ -104,7 +104,7 @@ def get_zip_size_on_s3(series_id: str):
                                     endpoint_url="http://localhost:9000",
                                     config=boto3.session.Config(s3={'addressing_style': 'path'}))
 
-    response = s3_client.head_object(Bucket="zip-bucket", Key=f"{series_id}.zip")
+    response = s3_client.head_object(Bucket="zip-bucket", Key=f"orthanc-zips/{series_id}.zip")
     return response['ContentLength']
 
 # --- Test scenario ---


### PR DESCRIPTION
## Ability to set a key prefix
See the `PrefixKey` configuration.

## Two changes useful in resource-constrained scenarios, for instance with a few very large series.

### 1. Do not evict series that are not uploaded yet

- After uploading a series to S3, write a `.s3-uploaded` marker file that contains the S3 object key
- Only evict, from the LRU cache, the series where this marker file is present.

### 2. Recovering series

- In the rare case where a series would have been fully uploaded but the container would die before being able to set the metadata (DB issue?), then use the contents of the `.s3-uploaded` file, if any.

## Misc 
A few fixes to remove mentions of "o8t" in the comments
