### PR TITLE
Various fixes (concurrency, race conditions) + S3 hardening

### DIFF
--- a/docker/python-s3-zip/Justfile
+++ b/docker/python-s3-zip/Justfile
@@ -1,0 +1,15 @@
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+_ensure-pytest:
+    uv run python -c "import pytest" 2>/dev/null || uv add --dev pytest
+
+# Run unit tests
+tests-unit: _ensure-pytest
+    uv run pytest tests/ --ignore=tests/test_scenario.py
+
+# Run integration tests (requires Docker + running services via docker-compose.yml)
+tests-integration:
+    uv run python tests/test_scenario.py
+
+# Run all tests
+tests-all: tests-unit tests-integration

--- a/docker/python-s3-zip/plugin/local_storage.py
+++ b/docker/python-s3-zip/plugin/local_storage.py
@@ -89,6 +89,10 @@ class LocalStorage(LocalStorageInterface):
     _available_size: int
     _block_size: int
     _lock: threading.RLock
+    _io_condition: threading.Condition
+    _active_writers: int
+    _scan_in_progress: bool
+    _reserved_bytes: int
     _folder_stats: queue.PriorityQueue[FolderStatEntry]
     _is_folder_safe_to_evict: Optional[Callable[[str], bool]]
 
@@ -96,6 +100,10 @@ class LocalStorage(LocalStorageInterface):
         self._root = root
         self._max_size = max_size_mb * 1024 * 1024
         self._lock = threading.RLock()
+        self._io_condition = threading.Condition()
+        self._active_writers = 0
+        self._scan_in_progress = False
+        self._reserved_bytes = 0
         self._is_folder_safe_to_evict = None
 
         self._update_local_storage_stats()
@@ -115,28 +123,63 @@ class LocalStorage(LocalStorageInterface):
         self._is_folder_safe_to_evict = is_folder_safe_to_evict
 
     def _update_local_storage_stats(self) -> None:
+        self._pause_writes_for_scan()
+        try:
+            self._update_local_storage_stats_with_writes_paused()
+        finally:
+            self._resume_writes_after_scan()
+
+    def _pause_writes_for_scan(self) -> None:
+        # A scan must not overlap physical writes: otherwise `du` can see a
+        # finished write while the reservation still counts it as in-flight.
+        with self._io_condition:
+            while self._scan_in_progress:
+                self._io_condition.wait()
+            self._scan_in_progress = True
+            while self._active_writers > 0:
+                self._io_condition.wait()
+
+    def _resume_writes_after_scan(self) -> None:
+        with self._io_condition:
+            self._scan_in_progress = False
+            self._io_condition.notify_all()
+
+    def _enter_write(self) -> None:
+        with self._io_condition:
+            while self._scan_in_progress:
+                self._io_condition.wait()
+            self._active_writers += 1
+
+    def _exit_write(self) -> None:
+        with self._io_condition:
+            self._active_writers -= 1
+            if self._active_writers == 0:
+                self._io_condition.notify_all()
+
+    def _update_local_storage_stats_with_writes_paused(self) -> None:
+        block_size: int = os.statvfs(self._root).f_frsize
+        folder_stats: queue.PriorityQueue[FolderStatEntry] = queue.PriorityQueue()
+
+        cmd: List[str] = ["du", "-b", "--max-depth=1", self._root]
+        result: subprocess.CompletedProcess[str] = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        lines: List[str] = result.stdout.strip().split("\n")
+
+        total_folders: int = 0
+        total_apparent_bytes: int = 0
+        for line in lines:
+            size_str, path = line.split("\t")
+            folder_size: int = int(size_str)
+            if path != self._root:
+                last_modified: float = os.path.getmtime(path)
+                folder_stats.put((last_modified, path, folder_size))
+                total_folders += 1
+                total_apparent_bytes += folder_size
+
         with self._lock:
             prev_available: Optional[int] = getattr(self, '_available_size', None)
-            self._available_size = self._max_size
-            self._block_size = os.statvfs(self._root).f_frsize
-
-            self._folder_stats = queue.PriorityQueue()
-
-            cmd: List[str] = ["du", "-b", "--max-depth=1", self._root]
-            result: subprocess.CompletedProcess[str] = subprocess.run(cmd, capture_output=True, text=True, check=True)
-            lines: List[str] = result.stdout.strip().split("\n")
-
-            total_folders: int = 0
-            total_apparent_bytes: int = 0
-            for line in lines:
-                size_str, path = line.split("\t")
-                folder_size: int = int(size_str)
-                if path != self._root:
-                    last_modified: float = os.path.getmtime(path)
-                    self._available_size -= folder_size
-                    self._folder_stats.put((last_modified, path, folder_size))
-                    total_folders += 1
-                    total_apparent_bytes += folder_size
+            self._block_size = block_size
+            self._folder_stats = folder_stats
+            self._available_size = self._max_size - total_apparent_bytes - self._reserved_bytes
 
             logger.debug(
                 "LocalStorage: disk stats refreshed",
@@ -146,6 +189,8 @@ class LocalStorage(LocalStorageInterface):
                 total_folders=total_folders,
                 total_apparent_bytes=total_apparent_bytes,
                 total_apparent_mb=round(total_apparent_bytes / (1024 * 1024), 2),
+                reserved_bytes=self._reserved_bytes,
+                reserved_mb=round(self._reserved_bytes / (1024 * 1024), 2),
                 available_bytes=self._available_size,
                 available_mb=round(self._available_size / (1024 * 1024), 2),
                 prev_available_bytes=prev_available,
@@ -155,7 +200,8 @@ class LocalStorage(LocalStorageInterface):
     def _evict_until(self, target_available_bytes: Optional[int]) -> EvictionResult:
         """Evict oldest-first folders until ``self._available_size`` reaches the target.
 
-        Caller MUST hold ``self._lock`` and MUST have refreshed
+        Caller MUST hold ``self._lock`` and MUST have paused writes via
+        ``_pause_writes_for_scan``. Caller also MUST have refreshed
         ``self._folder_stats`` (e.g. via ``_update_local_storage_stats``)
         before calling: this method neither acquires the lock nor refreshes
         the queue.
@@ -235,68 +281,120 @@ class LocalStorage(LocalStorageInterface):
             available_bytes_after=self._available_size,
         )
 
-    def _make_room(self, size: int) -> None:
+    def _make_room(self, size: int) -> int:
+        reservation_size: int = max(size, 0)
+
         with self._lock:
-            estimated_disk_size: int = ((size + self._block_size - 1) // self._block_size) * self._block_size
+            self._available_size -= reservation_size
+            self._reserved_bytes += reservation_size
 
             logger.debug(
                 "LocalStorage: _make_room called",
                 requested_bytes=size,
-                estimated_disk_bytes=estimated_disk_size,
+                reservation_bytes=reservation_size,
+                reserved_bytes=self._reserved_bytes,
                 current_available_bytes=self._available_size,
                 current_available_mb=round(self._available_size / (1024 * 1024), 2),
             )
 
-            if estimated_disk_size < self._available_size:
-                self._available_size -= estimated_disk_size
+            if self._available_size >= 0:
                 logger.debug(
                     "LocalStorage: fast path - sufficient space, no eviction needed",
                     available_after_bytes=self._available_size,
                     available_after_mb=round(self._available_size / (1024 * 1024), 2),
+                    reserved_bytes=self._reserved_bytes,
                 )
-                return
+                return reservation_size
 
             logger.debug(
                 "LocalStorage: slow path - available space insufficient, refreshing disk stats",
-                estimated_disk_bytes=estimated_disk_size,
+                reservation_bytes=reservation_size,
                 available_before_refresh_bytes=self._available_size,
+                reserved_bytes=self._reserved_bytes,
             )
-            self._update_local_storage_stats()
+
+        self._pause_writes_for_scan()
+        try:
+            self._update_local_storage_stats_with_writes_paused()
 
             logger.debug(
                 "LocalStorage: disk stats refreshed, starting eviction loop",
-                estimated_disk_bytes=estimated_disk_size,
-                available_after_refresh_bytes=self._available_size,
-                folders_queued=self._folder_stats.qsize(),
+                reservation_bytes=reservation_size,
             )
 
-            # Reclaim space -- evict oldest folders first, but protect folders
-            # whose data has not yet been safely backed up to S3.
-            # This can be useful if the plugin receives a burst of uploads that
-            # exceed the local storage capacity, but the S3 upload process is
-            # still catching up
-            result = self._evict_until(target_available_bytes=estimated_disk_size)
-
-            logger.debug(
-                "LocalStorage: eviction loop complete",
-                freed_folders=result.freed_folders,
-                freed_bytes=result.freed_bytes,
-                skipped_folders=result.skipped_folders,
-                estimated_disk_size=estimated_disk_size,
-                available_after_eviction_bytes=self._available_size,
-                available_after_eviction_mb=round(self._available_size / (1024 * 1024), 2),
-            )
-
-            if estimated_disk_size > self._available_size:
-                logger.warning(
-                    "LocalStorage: could not free enough space. "
-                    "Some folders are protected because they are not yet on S3.",
-                    needed=estimated_disk_size,
-                    available=self._available_size,
-                    available_mb=round(self._available_size / (1024 * 1024), 2),
-                    protected_folders=result.skipped_folders,
-                    max_size_mb=self._max_size // (1024 * 1024),
+            with self._lock:
+                logger.debug(
+                    "LocalStorage: starting eviction loop",
+                    reservation_bytes=reservation_size,
+                    available_after_refresh_bytes=self._available_size,
+                    reserved_bytes=self._reserved_bytes,
+                    folders_queued=self._folder_stats.qsize(),
                 )
+
+                # Reclaim space -- evict oldest folders first, but protect folders
+                # whose data has not yet been safely backed up to S3.
+                # This can be useful if the plugin receives a burst of uploads that
+                # exceed the local storage capacity, but the S3 upload process is
+                # still catching up
+                result = self._evict_until(target_available_bytes=0)
+
+                logger.debug(
+                    "LocalStorage: eviction loop complete",
+                    freed_folders=result.freed_folders,
+                    freed_bytes=result.freed_bytes,
+                    skipped_folders=result.skipped_folders,
+                    reservation_bytes=reservation_size,
+                    reserved_bytes=self._reserved_bytes,
+                    available_after_eviction_bytes=self._available_size,
+                    available_after_eviction_mb=round(self._available_size / (1024 * 1024), 2),
+                )
+
+                if self._available_size < 0:
+                    logger.warning(
+                        "LocalStorage: could not free enough space. "
+                        "Some folders are protected because they are not yet on S3.",
+                        needed=-self._available_size,
+                        available=self._available_size,
+                        available_mb=round(self._available_size / (1024 * 1024), 2),
+                        reserved_bytes=self._reserved_bytes,
+                        protected_folders=result.skipped_folders,
+                        max_size_mb=self._max_size // (1024 * 1024),
+                    )
+        finally:
+            self._resume_writes_after_scan()
+
+        return reservation_size
+
+    def _commit_write_reservation(self, reserved_bytes: int) -> None:
+        if reserved_bytes <= 0:
+            return
+
+        with self._lock:
+            self._reserved_bytes = max(0, self._reserved_bytes - reserved_bytes)
+            logger.debug(
+                "LocalStorage: write reservation committed",
+                released_reserved_bytes=reserved_bytes,
+                reserved_bytes=self._reserved_bytes,
+                available_bytes=self._available_size,
+            )
+
+    def _rollback_write_reservation(self, reserved_bytes: int) -> None:
+        if reserved_bytes <= 0:
+            return
+
+        with self._lock:
+            self._reserved_bytes = max(0, self._reserved_bytes - reserved_bytes)
+            self._available_size += reserved_bytes
+
+    def _touch_lru_reference(self, folder_path: str) -> None:
+        try:
+            os.utime(folder_path, None)
+        except OSError as e:
+            logger.debug(
+                "LocalStorage: failed to update folder LRU timestamp",
+                folder=folder_path,
+                error=str(e),
+            )
 
     def evict_all_safe(self) -> EvictionResult:
         """Force-evict every locally-cached series that has been safely uploaded to S3.
@@ -306,26 +404,31 @@ class LocalStorage(LocalStorageInterface):
         (``.s3-uploaded`` marker present) is removed from the local cache;
         folders still in flight are skipped and remain on disk.
 
-        Synchronous: holds ``self._lock`` for the entire pass, so concurrent
-        ``write_file`` / ``read_file`` calls are serialised behind it. The
-        cost is O(num_local_folders) ``shutil.rmtree`` calls plus one
+        Synchronous: pauses concurrent ``write_file`` disk writes during the
+        scan/eviction pass. The cost is O(num_local_folders) ``shutil.rmtree``
+        calls plus one
         ``du -b --max-depth=1`` invocation.
 
         Returns an ``EvictionResult`` describing what was freed.
         """
-        with self._lock:
-            self._update_local_storage_stats()
-            result = self._evict_until(target_available_bytes=None)
+        self._pause_writes_for_scan()
+        try:
+            self._update_local_storage_stats_with_writes_paused()
+            with self._lock:
+                result = self._evict_until(target_available_bytes=None)
 
-            logger.info(
-                "LocalStorage: evict_all_safe complete",
-                freed_folders=result.freed_folders,
-                freed_bytes=result.freed_bytes,
-                skipped_folders=result.skipped_folders,
-                available_after_bytes=self._available_size,
-                available_after_mb=round(self._available_size / (1024 * 1024), 2),
-            )
-            return result
+                logger.info(
+                    "LocalStorage: evict_all_safe complete",
+                    freed_folders=result.freed_folders,
+                    freed_bytes=result.freed_bytes,
+                    skipped_folders=result.skipped_folders,
+                    available_after_bytes=self._available_size,
+                    available_after_mb=round(self._available_size / (1024 * 1024), 2),
+                    reserved_bytes=self._reserved_bytes,
+                )
+                return result
+        finally:
+            self._resume_writes_after_scan()
 
     def get_cache_summary(self, marker_filename: str = ".s3-uploaded") -> Dict[str, int]:
         """Return a snapshot of local-cache occupancy.
@@ -336,9 +439,9 @@ class LocalStorage(LocalStorageInterface):
 
         The counts are advisory — they are racy with the upload thread.
         """
-        with self._lock:
-            self._update_local_storage_stats()
-            total_folders: int = self._folder_stats.qsize()
+        self._pause_writes_for_scan()
+        try:
+            self._update_local_storage_stats_with_writes_paused()
             uploaded: int = 0
             pending: int = 0
             try:
@@ -352,24 +455,50 @@ class LocalStorage(LocalStorageInterface):
                         pending += 1
             except FileNotFoundError:
                 pass
-            used_bytes: int = self._max_size - self._available_size
-            return {
-                "max_bytes": self._max_size,
-                "available_bytes": self._available_size,
-                "used_bytes": used_bytes,
-                "total_folders": total_folders,
-                "folders_on_s3": uploaded,
-                "folders_not_on_s3": pending,
-            }
+            with self._lock:
+                total_folders: int = self._folder_stats.qsize()
+                used_bytes: int = self._max_size - self._available_size
+                return {
+                    "max_bytes": self._max_size,
+                    "available_bytes": self._available_size,
+                    "used_bytes": used_bytes,
+                    "reserved_bytes": self._reserved_bytes,
+                    "total_folders": total_folders,
+                    "folders_on_s3": uploaded,
+                    "folders_not_on_s3": pending,
+                }
+        finally:
+            self._resume_writes_after_scan()
 
 
     def write_file(self, local_series_folder: str, uuid: str, content: bytes) -> None:
-        self._make_room(len(content))
+        reserved_bytes: int = self._make_room(len(content))
+        write_failed: bool = False
 
-        self._write_file(uuid=uuid,
-                         local_series_folder=local_series_folder,
-                         content_type=orthanc.ContentType.DICOM,
-                         content=content)
+        self._enter_write()
+        try:
+            try:
+                self._write_file(uuid=uuid,
+                                 local_series_folder=local_series_folder,
+                                 content_type=orthanc.ContentType.DICOM,
+                                 content=content)
+            except Exception:
+                write_failed = True
+                self._rollback_write_reservation(reserved_bytes)
+                raise
+            else:
+                self._commit_write_reservation(reserved_bytes)
+        finally:
+            self._exit_write()
+            if write_failed:
+                try:
+                    self._update_local_storage_stats()
+                except Exception as e:
+                    logger.warning(
+                        "LocalStorage: failed to refresh stats after write failure; restored reservation optimistically",
+                        released_reserved_bytes=reserved_bytes,
+                        error=str(e),
+                    )
 
 
     def _write_file(self, uuid: str, local_series_folder: str, content_type: orthanc.ContentType, content: bytes) -> None:
@@ -389,9 +518,7 @@ class LocalStorage(LocalStorageInterface):
         with open(path, "wb") as f:
             f.write(content)
 
-        # with self._lock:
-
-        # TODO: increment used_size + LRU references
+        self._touch_lru_reference(os.path.dirname(path))
 
         logger.debug("file written to local storage",
                      uuid=uuid,

--- a/docker/python-s3-zip/plugin/local_storage.py
+++ b/docker/python-s3-zip/plugin/local_storage.py
@@ -184,8 +184,17 @@ class LocalStorage(LocalStorageInterface):
             while self._scan_in_progress:
                 self._io_condition.wait()
             self._scan_in_progress = True
-            while self._active_writers > 0:
-                self._io_condition.wait()
+            # If wait() is interrupted (e.g. by a signal) after we have already
+            # claimed the scan slot, we must clear the flag and wake any other
+            # blocked threads. Otherwise _scan_in_progress stays True forever
+            # and every subsequent _enter_write / scan-pauser deadlocks.
+            try:
+                while self._active_writers > 0:
+                    self._io_condition.wait()
+            except BaseException:
+                self._scan_in_progress = False
+                self._io_condition.notify_all()
+                raise
 
     def _resume_writes_after_scan(self) -> None:
         with self._io_condition:
@@ -733,10 +742,14 @@ class LocalStorage(LocalStorageInterface):
                                         local_series_folder=local_series_folder,
                                         content_type=content_type)
 
-        existed: bool = os.path.exists(path)
-
-        if existed:
+        # os.path.exists() + os.remove() is not atomic: eviction can rmtree
+        # the parent folder between the two calls. Catch FileNotFoundError
+        # rather than letting it surface as a storage callback error.
+        try:
             os.remove(path)
+            existed: bool = True
+        except FileNotFoundError:
+            existed = False
 
         logger.debug("remove called",
                      uuid=uuid,

--- a/docker/python-s3-zip/plugin/local_storage.py
+++ b/docker/python-s3-zip/plugin/local_storage.py
@@ -94,9 +94,10 @@ class LocalStorage(LocalStorageInterface):
     _active_writers: int
     _scan_in_progress: bool
     _reserved_bytes: int
-    _folder_lease_counts: Dict[str, int]
+    _folder_lease_counts: dict[str, int]
+    _folder_marker_cs_locks: dict[str, tuple[threading.Lock, int]]
     _folder_stats: queue.PriorityQueue[FolderStatEntry]
-    _is_folder_safe_to_evict: Optional[Callable[[str], bool]]
+    _is_folder_safe_to_evict: Callable[[str], bool] | None
 
     def __init__(self, root: str, max_size_mb: int) -> None:
         self._root = root
@@ -107,6 +108,7 @@ class LocalStorage(LocalStorageInterface):
         self._scan_in_progress = False
         self._reserved_bytes = 0
         self._folder_lease_counts = {}
+        self._folder_marker_cs_locks = {}
         self._is_folder_safe_to_evict = None
 
         self._update_local_storage_stats()
@@ -169,6 +171,50 @@ class LocalStorage(LocalStorageInterface):
 
     def _get_folder_lease_count(self, local_series_folder: str) -> int:
         return self._folder_lease_counts.get(local_series_folder, 0)
+
+    @contextmanager
+    def folder_marker_critical_section(self, local_series_folder: str) -> Iterator[None]:
+        """Per-folder mutex for marker publish/invalidate operations.
+
+        Two paths race for the marker file: ``copy_series_to_s3`` writes it
+        after a final attachment-set recheck, and ``storage_create`` deletes
+        it whenever a new instance lands on disk. Without serialization, the
+        copy can publish a marker AFTER the create's delete has already run
+        as a no-op, leaving a stale marker that hides an un-uploaded file.
+
+        Acquiring is refcounted: the underlying ``threading.Lock`` is created
+        lazily on first use and removed from the dict when no thread is in
+        the section, so memory does not grow with the lifetime catalogue of
+        series folders.
+        """
+        lock = self._acquire_folder_marker_cs(local_series_folder)
+        try:
+            with lock:
+                yield
+        finally:
+            self._release_folder_marker_cs(local_series_folder)
+
+    def _acquire_folder_marker_cs(self, local_series_folder: str) -> threading.Lock:
+        with self._lock:
+            entry = self._folder_marker_cs_locks.get(local_series_folder)
+            if entry is None:
+                new_lock = threading.Lock()
+                self._folder_marker_cs_locks[local_series_folder] = (new_lock, 1)
+                return new_lock
+            existing_lock, count = entry
+            self._folder_marker_cs_locks[local_series_folder] = (existing_lock, count + 1)
+            return existing_lock
+
+    def _release_folder_marker_cs(self, local_series_folder: str) -> None:
+        with self._lock:
+            entry = self._folder_marker_cs_locks.get(local_series_folder)
+            if entry is None:
+                return
+            existing_lock, count = entry
+            if count <= 1:
+                del self._folder_marker_cs_locks[local_series_folder]
+            else:
+                self._folder_marker_cs_locks[local_series_folder] = (existing_lock, count - 1)
 
     def _update_local_storage_stats(self) -> None:
         self._pause_writes_for_scan()

--- a/docker/python-s3-zip/plugin/local_storage.py
+++ b/docker/python-s3-zip/plugin/local_storage.py
@@ -8,8 +8,9 @@ import threading
 import subprocess
 import queue
 import shutil
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple
+from typing import Any, Callable, ClassVar, Dict, Iterator, List, Optional, Tuple
 from local_storage_interface import LocalStorageInterface
 from collections import deque
 from s3zip_logging import get_logger
@@ -93,6 +94,7 @@ class LocalStorage(LocalStorageInterface):
     _active_writers: int
     _scan_in_progress: bool
     _reserved_bytes: int
+    _folder_lease_counts: Dict[str, int]
     _folder_stats: queue.PriorityQueue[FolderStatEntry]
     _is_folder_safe_to_evict: Optional[Callable[[str], bool]]
 
@@ -104,6 +106,7 @@ class LocalStorage(LocalStorageInterface):
         self._active_writers = 0
         self._scan_in_progress = False
         self._reserved_bytes = 0
+        self._folder_lease_counts = {}
         self._is_folder_safe_to_evict = None
 
         self._update_local_storage_stats()
@@ -121,6 +124,51 @@ class LocalStorage(LocalStorageInterface):
         - If this callback is not set, all folders are considered safe to evict.
         """
         self._is_folder_safe_to_evict = is_folder_safe_to_evict
+
+    @contextmanager
+    def lease_folder(self, local_series_folder: str) -> Iterator[None]:
+        """Keep a series folder stable while a caller depends on its contents.
+
+        Eviction removes whole series folders. A caller that checks a file path
+        and then opens it, or extracts several files into the same folder, needs
+        the folder to remain present for the full operation rather than only for
+        one filesystem call. The lease is a refcount checked by eviction; it is
+        not a global I/O mutex.
+        """
+        self._acquire_folder_lease(local_series_folder)
+        try:
+            yield
+        finally:
+            self._release_folder_lease(local_series_folder)
+
+    def _acquire_folder_lease(self, local_series_folder: str) -> None:
+        with self._lock:
+            self._folder_lease_counts[local_series_folder] = (
+                self._folder_lease_counts.get(local_series_folder, 0) + 1
+            )
+            logger.debug(
+                "LocalStorage: folder lease acquired",
+                local_series_folder=local_series_folder,
+                lease_count=self._folder_lease_counts[local_series_folder],
+            )
+
+    def _release_folder_lease(self, local_series_folder: str) -> None:
+        with self._lock:
+            lease_count = self._folder_lease_counts.get(local_series_folder, 0)
+            if lease_count <= 1:
+                self._folder_lease_counts.pop(local_series_folder, None)
+                lease_count = 0
+            else:
+                lease_count -= 1
+                self._folder_lease_counts[local_series_folder] = lease_count
+            logger.debug(
+                "LocalStorage: folder lease released",
+                local_series_folder=local_series_folder,
+                lease_count=lease_count,
+            )
+
+    def _get_folder_lease_count(self, local_series_folder: str) -> int:
+        return self._folder_lease_counts.get(local_series_folder, 0)
 
     def _update_local_storage_stats(self) -> None:
         self._pause_writes_for_scan()
@@ -212,10 +260,11 @@ class LocalStorage(LocalStorageInterface):
                 ``None`` to drain the LRU queue completely (i.e. evict
                 everything that the eviction guard considers safe to evict).
 
-        Folders without a ``.s3-uploaded`` marker are protected by the
-        eviction guard set via ``set_eviction_guard`` and are skipped, then
-        put back into the queue at the end so they remain candidates for
-        future eviction.
+        Folders with active leases are skipped because another thread is using
+        their contents across multiple filesystem calls. Folders without a
+        ``.s3-uploaded`` marker are protected by the eviction guard set via
+        ``set_eviction_guard``. Skipped folders are put back into the queue so
+        they remain candidates for future eviction.
         """
         skipped: List[FolderStatEntry] = []
         freed_bytes: int = 0
@@ -231,6 +280,15 @@ class LocalStorage(LocalStorageInterface):
             _, path, folder_size = entry
 
             folder_name: str = os.path.basename(path)
+            lease_count = self._get_folder_lease_count(folder_name)
+            if lease_count > 0:
+                logger.info(
+                    "LocalStorage: skipping eviction of leased folder",
+                    folder=folder_name,
+                    folder_size=folder_size,
+                    lease_count=lease_count)
+                skipped.append(entry)
+                continue
 
             if self._is_folder_safe_to_evict is not None:
                 try:
@@ -313,8 +371,10 @@ class LocalStorage(LocalStorageInterface):
                 reserved_bytes=self._reserved_bytes,
             )
 
-        self._pause_writes_for_scan()
+        scan_paused = False
         try:
+            self._pause_writes_for_scan()
+            scan_paused = True
             self._update_local_storage_stats_with_writes_paused()
 
             logger.debug(
@@ -360,8 +420,12 @@ class LocalStorage(LocalStorageInterface):
                         protected_folders=result.skipped_folders,
                         max_size_mb=self._max_size // (1024 * 1024),
                     )
+        except Exception:
+            self._rollback_write_reservation(reservation_size)
+            raise
         finally:
-            self._resume_writes_after_scan()
+            if scan_paused:
+                self._resume_writes_after_scan()
 
         return reservation_size
 

--- a/docker/python-s3-zip/plugin/local_storage.py
+++ b/docker/python-s3-zip/plugin/local_storage.py
@@ -313,10 +313,23 @@ class LocalStorage(LocalStorageInterface):
                 available_before=self._available_size,
             )
 
-            # TODO: handle errors here (e.g. if the file gets locked by
-            # another process, or if it is being deleted by someone trying
-            # to help! Unlikely but what can go wrong will go wrong...)
-            shutil.rmtree(path)
+            try:
+                shutil.rmtree(path)
+            except FileNotFoundError:
+                logger.info(
+                    "LocalStorage: folder already gone during eviction",
+                    folder=folder_name,
+                    folder_size=folder_size,
+                )
+            except OSError as e:
+                logger.warning(
+                    "LocalStorage: failed to evict folder, leaving it queued for a future pass",
+                    folder=folder_name,
+                    folder_size=folder_size,
+                    error=str(e),
+                )
+                skipped.append(entry)
+                continue
             self._available_size += folder_size
             freed_bytes += folder_size
             freed_folders += 1

--- a/docker/python-s3-zip/plugin/local_storage.py
+++ b/docker/python-s3-zip/plugin/local_storage.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import orthanc
@@ -7,10 +9,12 @@ import subprocess
 import queue
 import shutil
 from dataclasses import dataclass
-from typing import Callable, Tuple, Optional
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple
 from local_storage_interface import LocalStorageInterface
 from collections import deque
 from s3zip_logging import get_logger
+
+FolderStatEntry = Tuple[float, str, int]
 
 
 @dataclass
@@ -44,9 +48,9 @@ logger = get_logger(__name__)
 #   S3ZIP_LOCAL_STORAGE_LOG_LEVEL: DEBUG
 # ---------------------------------------------------------------------------
 _LOCAL_STORAGE_LOG_LEVEL_ENV_VAR = "S3ZIP_LOCAL_STORAGE_LOG_LEVEL"
-_module_level_override = os.environ.get(_LOCAL_STORAGE_LOG_LEVEL_ENV_VAR)
+_module_level_override: Optional[str] = os.environ.get(_LOCAL_STORAGE_LOG_LEVEL_ENV_VAR)
 if _module_level_override:
-    _lvl = getattr(logging, _module_level_override.upper(), None)
+    _lvl: Any = getattr(logging, _module_level_override.upper(), None)
     if _lvl is not None:
         # Set the level on this module's logger so isEnabledFor() returns True for
         # records at the override level.
@@ -60,7 +64,7 @@ if _module_level_override:
         # and replaced by the root-logger handler (level=NOTSET=0), so this adjustment is
         # only relevant during the import-time window and in standalone setups that never
         # call inject_logger_factory().
-        _s3zip_root = logging.getLogger("s3zip")
+        _s3zip_root: logging.Logger = logging.getLogger("s3zip")
         for _h in _s3zip_root.handlers:
             if _lvl < _h.level:
                 _h.setLevel(_lvl)
@@ -85,10 +89,10 @@ class LocalStorage(LocalStorageInterface):
     _available_size: int
     _block_size: int
     _lock: threading.RLock
-    _folder_stats: queue.PriorityQueue
+    _folder_stats: queue.PriorityQueue[FolderStatEntry]
     _is_folder_safe_to_evict: Optional[Callable[[str], bool]]
 
-    def __init__(self, root: str, max_size_mb: int):
+    def __init__(self, root: str, max_size_mb: int) -> None:
         self._root = root
         self._max_size = max_size_mb * 1024 * 1024
         self._lock = threading.RLock()
@@ -101,7 +105,7 @@ class LocalStorage(LocalStorageInterface):
                      max_size_mb=max_size_mb,
                      max_size_bytes=self._max_size)
 
-    def set_eviction_guard(self, is_folder_safe_to_evict: callable):
+    def set_eviction_guard(self, is_folder_safe_to_evict: Callable[[str], bool]) -> None:
         """
         - Set a callback that determines if a local series folder is safe to evict.
         - The callback receives the folder name (not the full path) and
@@ -110,25 +114,25 @@ class LocalStorage(LocalStorageInterface):
         """
         self._is_folder_safe_to_evict = is_folder_safe_to_evict
 
-    def _update_local_storage_stats(self):
+    def _update_local_storage_stats(self) -> None:
         with self._lock:
-            prev_available = getattr(self, '_available_size', None)
+            prev_available: Optional[int] = getattr(self, '_available_size', None)
             self._available_size = self._max_size
             self._block_size = os.statvfs(self._root).f_frsize
 
             self._folder_stats = queue.PriorityQueue()
 
-            cmd = ["du", "-b", "--max-depth=1", self._root]
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-            lines = result.stdout.strip().split("\n")
+            cmd: List[str] = ["du", "-b", "--max-depth=1", self._root]
+            result: subprocess.CompletedProcess[str] = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            lines: List[str] = result.stdout.strip().split("\n")
 
-            total_folders = 0
-            total_apparent_bytes = 0
+            total_folders: int = 0
+            total_apparent_bytes: int = 0
             for line in lines:
                 size_str, path = line.split("\t")
-                folder_size = int(size_str)
+                folder_size: int = int(size_str)
                 if path != self._root:
-                    last_modified = os.path.getmtime(path)
+                    last_modified: float = os.path.getmtime(path)
                     self._available_size -= folder_size
                     self._folder_stats.put((last_modified, path, folder_size))
                     total_folders += 1
@@ -167,9 +171,9 @@ class LocalStorage(LocalStorageInterface):
         put back into the queue at the end so they remain candidates for
         future eviction.
         """
-        skipped = []
-        freed_bytes = 0
-        freed_folders = 0
+        skipped: List[FolderStatEntry] = []
+        freed_bytes: int = 0
+        freed_folders: int = 0
 
         def _need_more() -> bool:
             if target_available_bytes is None:
@@ -177,10 +181,10 @@ class LocalStorage(LocalStorageInterface):
             return self._available_size < target_available_bytes
 
         while _need_more() and not self._folder_stats.empty():
-            entry = self._folder_stats.get()
+            entry: FolderStatEntry = self._folder_stats.get()
             _, path, folder_size = entry
 
-            folder_name = os.path.basename(path)
+            folder_name: str = os.path.basename(path)
 
             if self._is_folder_safe_to_evict is not None:
                 try:
@@ -231,9 +235,9 @@ class LocalStorage(LocalStorageInterface):
             available_bytes_after=self._available_size,
         )
 
-    def _make_room(self, size: int):
+    def _make_room(self, size: int) -> None:
         with self._lock:
-            estimated_disk_size = ((size + self._block_size - 1) // self._block_size) * self._block_size
+            estimated_disk_size: int = ((size + self._block_size - 1) // self._block_size) * self._block_size
 
             logger.debug(
                 "LocalStorage: _make_room called",
@@ -323,7 +327,7 @@ class LocalStorage(LocalStorageInterface):
             )
             return result
 
-    def get_cache_summary(self, marker_filename: str = ".s3-uploaded") -> dict:
+    def get_cache_summary(self, marker_filename: str = ".s3-uploaded") -> Dict[str, int]:
         """Return a snapshot of local-cache occupancy.
 
         Refreshes the disk stats (does NOT evict) and walks the temp folder
@@ -334,12 +338,12 @@ class LocalStorage(LocalStorageInterface):
         """
         with self._lock:
             self._update_local_storage_stats()
-            total_folders = self._folder_stats.qsize()
-            uploaded = 0
-            pending = 0
+            total_folders: int = self._folder_stats.qsize()
+            uploaded: int = 0
+            pending: int = 0
             try:
                 for name in os.listdir(self._root):
-                    folder = os.path.join(self._root, name)
+                    folder: str = os.path.join(self._root, name)
                     if not os.path.isdir(folder):
                         continue
                     if os.path.exists(os.path.join(folder, marker_filename)):
@@ -348,7 +352,7 @@ class LocalStorage(LocalStorageInterface):
                         pending += 1
             except FileNotFoundError:
                 pass
-            used_bytes = self._max_size - self._available_size
+            used_bytes: int = self._max_size - self._available_size
             return {
                 "max_bytes": self._max_size,
                 "available_bytes": self._available_size,
@@ -359,7 +363,7 @@ class LocalStorage(LocalStorageInterface):
             }
 
 
-    def write_file(self, local_series_folder: str, uuid: str, content: bytes):
+    def write_file(self, local_series_folder: str, uuid: str, content: bytes) -> None:
         self._make_room(len(content))
 
         self._write_file(uuid=uuid,
@@ -368,11 +372,11 @@ class LocalStorage(LocalStorageInterface):
                          content=content)
 
 
-    def _write_file(self, uuid: str, local_series_folder: str, content_type: orthanc.ContentType, content: bytes):
+    def _write_file(self, uuid: str, local_series_folder: str, content_type: orthanc.ContentType, content: bytes) -> None:
 
-        path = self.get_local_path(uuid=uuid,
-                                   local_series_folder=local_series_folder,
-                                   content_type=content_type)
+        path: str = self.get_local_path(uuid=uuid,
+                                        local_series_folder=local_series_folder,
+                                        content_type=content_type)
 
         logger.debug("writing file to local storage",
                      uuid=uuid,
@@ -409,9 +413,9 @@ class LocalStorage(LocalStorageInterface):
                    range_start: int,
                    size: int) -> bytes:
 
-        path = self.get_local_path(uuid=uuid,
-                                   local_series_folder=local_series_folder,
-                                   content_type=content_type)
+        path: str = self.get_local_path(uuid=uuid,
+                                        local_series_folder=local_series_folder,
+                                        content_type=content_type)
 
         logger.debug("reading file from local storage",
                      uuid=uuid,
@@ -424,7 +428,7 @@ class LocalStorage(LocalStorageInterface):
                 f.seek(range_start)
 
             if size > 0:
-                data = f.read(size)
+                data: bytes = f.read(size)
             else:
                 data = f.read()
 
@@ -436,7 +440,7 @@ class LocalStorage(LocalStorageInterface):
         return data
 
 
-    SUPPORTED_CONTENT_TYPES = (orthanc.ContentType.DICOM, orthanc.ContentType.DICOM_UNTIL_PIXEL_DATA)
+    SUPPORTED_CONTENT_TYPES: ClassVar[Tuple[orthanc.ContentType, ...]] = (orthanc.ContentType.DICOM, orthanc.ContentType.DICOM_UNTIL_PIXEL_DATA)
 
     def create(self,
                uuid: str,
@@ -490,11 +494,11 @@ class LocalStorage(LocalStorageInterface):
                      size=size)
 
         try:
-            data = self._read_file(uuid=uuid,
-                                   local_series_folder=local_series_folder,
-                                   content_type=content_type,
-                                   range_start=range_start,
-                                   size=size)
+            data: bytes = self._read_file(uuid=uuid,
+                                          local_series_folder=local_series_folder,
+                                          content_type=content_type,
+                                          range_start=range_start,
+                                          size=size)
 
             logger.debug("read_range succeeded",
                          uuid=uuid,
@@ -517,15 +521,15 @@ class LocalStorage(LocalStorageInterface):
     def remove(self,
                uuid: str,
                local_series_folder: str,
-               content_type: orthanc.ContentType):
+               content_type: orthanc.ContentType) -> None:
 
         # TODO: we should probably implement an asynchronous file deleter
 
-        path = self.get_local_path(uuid=uuid,
-                                   local_series_folder=local_series_folder,
-                                   content_type=content_type)
+        path: str = self.get_local_path(uuid=uuid,
+                                        local_series_folder=local_series_folder,
+                                        content_type=content_type)
 
-        existed = os.path.exists(path)
+        existed: bool = os.path.exists(path)
 
         if existed:
             os.remove(path)
@@ -548,10 +552,10 @@ class LocalStorage(LocalStorageInterface):
         return os.path.join(self._root, local_series_folder)
 
     def has_local_file(self, uuid: str, local_series_folder: str, content_type: orthanc.ContentType) -> bool:
-        path = self.get_local_path(uuid=uuid,
-                                   local_series_folder=local_series_folder,
-                                   content_type=content_type)
-        exists = os.path.exists(path)
+        path: str = self.get_local_path(uuid=uuid,
+                                        local_series_folder=local_series_folder,
+                                        content_type=content_type)
+        exists: bool = os.path.exists(path)
 
         logger.debug("has_local_file check",
                      uuid=uuid,

--- a/docker/python-s3-zip/plugin/local_storage_interface.py
+++ b/docker/python-s3-zip/plugin/local_storage_interface.py
@@ -1,6 +1,11 @@
 from abc import ABC, abstractmethod
+from contextlib import AbstractContextManager
 
 class LocalStorageInterface(ABC):
+
+    @abstractmethod
+    def lease_folder(self, local_series_folder: str) -> AbstractContextManager[None]:
+        pass
 
     @abstractmethod
     def write_file(self, local_series_folder: str, uuid: str, content: bytes):

--- a/docker/python-s3-zip/plugin/local_storage_interface.py
+++ b/docker/python-s3-zip/plugin/local_storage_interface.py
@@ -8,6 +8,10 @@ class LocalStorageInterface(ABC):
         pass
 
     @abstractmethod
+    def folder_marker_critical_section(self, local_series_folder: str) -> AbstractContextManager[None]:
+        pass
+
+    @abstractmethod
     def write_file(self, local_series_folder: str, uuid: str, content: bytes):
         pass
 

--- a/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
+++ b/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
@@ -47,30 +47,30 @@ class LocalToS3ZipManager:
             self._ref_count = 0
             self._manager = manager
             self._downloaded = False
-            logger.debug("ZipRetrieval created", s3_zip_key=series_id)
+            logger.debug("ZipRetrieval created", series_id=series_id)
 
         def __enter__(self):
             logger.debug("ZipRetrieval entering (acquiring condition)",
-                         s3_zip_key=self.series_id,
+                         series_id=self.series_id,
                          ref_count=self._ref_count + 1)
             self._ref_count += 1
             self._condition.__enter__()
             logger.debug("ZipRetrieval entered (condition acquired)",
-                         s3_zip_key=self.series_id,
+                         series_id=self.series_id,
                          ref_count=self._ref_count)
 
         def __exit__(self, exc_type, exc_val, exc_tb):
             logger.debug("ZipRetrieval exiting",
-                         s3_zip_key=self.series_id,
+                         series_id=self.series_id,
                          ref_count=self._ref_count)
             self._ref_count -= 1
             self._condition.__exit__(exc_type, exc_val, exc_tb)
             if self._ref_count == 0:
                 logger.debug("ZipRetrieval ref_count reached 0, discarding",
-                             s3_zip_key=self.series_id)
+                             series_id=self.series_id)
                 self._manager._discard_zip_retrieval(self.series_id)
             logger.debug("ZipRetrieval exited",
-                         s3_zip_key=self.series_id,
+                         series_id=self.series_id,
                          ref_count=self._ref_count)
 
         @property
@@ -79,17 +79,17 @@ class LocalToS3ZipManager:
 
         def set_downloaded(self):
             logger.debug("ZipRetrieval set_downloaded, notifying waiters",
-                         s3_zip_key=self.series_id)
+                         series_id=self.series_id)
             self._downloaded = True
             self._condition.notify_all()
 
         def wait_downloaded(self):
             logger.debug("ZipRetrieval waiting for download to complete",
-                         s3_zip_key=self.series_id)
+                         series_id=self.series_id)
             while not self._downloaded:
                 self._condition.wait()
             logger.debug("ZipRetrieval download wait completed",
-                         s3_zip_key=self.series_id)
+                         series_id=self.series_id)
 
     _s3_client: S3Client
     _local_storage: LocalStorageInterface
@@ -492,4 +492,4 @@ class LocalToS3ZipManager:
                 status.s3_zip_key = cd.s3_zip_key
 
         return status
-    
+

--- a/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
+++ b/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
@@ -380,42 +380,49 @@ class LocalToS3ZipManager:
                             s3_key=s3_key,
                             metadata_update_ms=int((t_meta_done - t_meta_start) * 1000))
 
-                # Re-check the attachment set: if a new instance landed for
-                # this series after the initial snapshot, the uploaded zip is
-                # already incomplete. Skip the marker so eviction cannot purge
-                # the folder. The next stable-series event will trigger another
-                # copy that includes the new instance(s) and publishes a fresh
-                # marker.
-                current_attachments: list[str] = self._get_instances_attachments(series_id=series_id)
-                attachments_changed: bool = set(current_attachments) != set(attachments_uuids)
+                # Re-check the attachment set under the per-folder marker
+                # critical section: if a new instance landed for this series
+                # after the initial snapshot, the uploaded zip is already
+                # incomplete. Skip the marker so eviction cannot purge the
+                # folder. The critical section serializes against
+                # storage_create's marker invalidation, so a concurrent new
+                # write cannot interleave between our recheck and our marker
+                # write and leave a stale marker behind. The next
+                # stable-series event will trigger another copy that includes
+                # the new instance(s) and publishes a fresh marker.
+                if local_series_folder:
+                    with self._local_storage.folder_marker_critical_section(local_series_folder):
+                        current_attachments: list[str] = self._get_instances_attachments(series_id=series_id)
+                        attachments_changed: bool = set(current_attachments) != set(attachments_uuids)
 
-                # The marker is the eviction guard's durable signal that the
-                # folder contents are recoverable from S3. It is written while
-                # the folder lease is active so eviction cannot remove the
-                # directory between opening the marker and atomically publishing
-                # its final path.
-                if local_series_folder and not attachments_changed:
-                    self._write_s3_uploaded_marker(
-                        local_series_folder=local_series_folder,
-                        s3_key=s3_key,
-                        series_id=series_id,
-                    )
-                elif local_series_folder and attachments_changed:
-                    new_uuids = sorted(
-                        set(current_attachments) - set(attachments_uuids)
-                    )
-                    dropped_uuids = sorted(
-                        set(attachments_uuids) - set(current_attachments)
-                    )
-                    logger.warning(
-                        msg="attachment set changed during S3 copy; skipping marker write (next stable-series event will trigger a fresh copy)",
-                        series_id=series_id,
-                        s3_key=s3_key,
-                        snapshot_count=len(attachments_uuids),
-                        current_count=len(current_attachments),
-                        new_uuids=new_uuids,
-                        dropped_uuids=dropped_uuids,
-                    )
+                        # The marker is the eviction guard's durable signal
+                        # that the folder contents are recoverable from S3. It
+                        # is written while the folder lease is active so
+                        # eviction cannot remove the folder between the
+                        # tmp-file open in _write_s3_uploaded_marker step 1 and
+                        # the atomic os.replace to .s3-uploaded in step 2.
+                        if not attachments_changed:
+                            self._write_s3_uploaded_marker(
+                                local_series_folder=local_series_folder,
+                                s3_key=s3_key,
+                                series_id=series_id,
+                            )
+                        else:
+                            new_uuids = sorted(
+                                set(current_attachments) - set(attachments_uuids)
+                            )
+                            dropped_uuids = sorted(
+                                set(attachments_uuids) - set(current_attachments)
+                            )
+                            logger.warning(
+                                msg="attachment set changed during S3 copy; skipping marker write (next stable-series event will trigger a fresh copy)",
+                                series_id=series_id,
+                                s3_key=s3_key,
+                                snapshot_count=len(attachments_uuids),
+                                current_count=len(current_attachments),
+                                new_uuids=new_uuids,
+                                dropped_uuids=dropped_uuids,
+                            )
 
         duration_ms = int((time.monotonic() - t0) * 1000)
 

--- a/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
+++ b/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
@@ -380,16 +380,41 @@ class LocalToS3ZipManager:
                             s3_key=s3_key,
                             metadata_update_ms=int((t_meta_done - t_meta_start) * 1000))
 
+                # Re-check the attachment set: if a new instance landed for
+                # this series after the initial snapshot, the uploaded zip is
+                # already incomplete. Skip the marker so eviction cannot purge
+                # the folder. The next stable-series event will trigger another
+                # copy that includes the new instance(s) and publishes a fresh
+                # marker.
+                current_attachments: list[str] = self._get_instances_attachments(series_id=series_id)
+                attachments_changed: bool = set(current_attachments) != set(attachments_uuids)
+
                 # The marker is the eviction guard's durable signal that the
                 # folder contents are recoverable from S3. It is written while
                 # the folder lease is active so eviction cannot remove the
                 # directory between opening the marker and atomically publishing
                 # its final path.
-                if local_series_folder:
+                if local_series_folder and not attachments_changed:
                     self._write_s3_uploaded_marker(
                         local_series_folder=local_series_folder,
                         s3_key=s3_key,
                         series_id=series_id,
+                    )
+                elif local_series_folder and attachments_changed:
+                    new_uuids = sorted(
+                        set(current_attachments) - set(attachments_uuids)
+                    )
+                    dropped_uuids = sorted(
+                        set(attachments_uuids) - set(current_attachments)
+                    )
+                    logger.warning(
+                        msg="attachment set changed during S3 copy; skipping marker write (next stable-series event will trigger a fresh copy)",
+                        series_id=series_id,
+                        s3_key=s3_key,
+                        snapshot_count=len(attachments_uuids),
+                        current_count=len(current_attachments),
+                        new_uuids=new_uuids,
+                        dropped_uuids=dropped_uuids,
                     )
 
         duration_ms = int((time.monotonic() - t0) * 1000)
@@ -441,6 +466,31 @@ class LocalToS3ZipManager:
                            series_id=series_id,
                            marker_path=marker_path,
                            error=str(e))
+
+    def invalidate_s3_uploaded_marker(self, local_series_folder: str) -> bool:
+        """Remove the ``.s3-uploaded`` marker for ``local_series_folder``.
+
+        Called on every storage_create for a series: any new instance landing
+        on disk invalidates the marker's invariant ("everything in this folder
+        is recoverable from S3"). Best effort -- a missing marker is the
+        expected steady state.
+        """
+        folder_path = self._local_storage.get_folder_path(local_series_folder)
+        marker_path = os.path.join(folder_path, ".s3-uploaded")
+        try:
+            os.remove(marker_path)
+            logger.debug("invalidated S3 upload marker",
+                         local_series_folder=local_series_folder,
+                         marker_path=marker_path)
+            return True
+        except FileNotFoundError:
+            return False
+        except OSError as e:
+            logger.warning("failed to invalidate S3 upload marker",
+                           local_series_folder=local_series_folder,
+                           marker_path=marker_path,
+                           error=str(e))
+            return False
 
     def _fsync_directory_if_supported(self, folder_path: str):
         if not hasattr(os, "O_DIRECTORY"):

--- a/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
+++ b/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
@@ -2,9 +2,11 @@ import orthanc
 import json
 import zipfile
 import os
+import random
 import tempfile
 import threading
 import time
+from contextlib import ExitStack
 from typing import List, Dict, Optional, Tuple
 from boto3 import client as S3Client
 from local_storage_interface import LocalStorageInterface
@@ -12,7 +14,57 @@ from uncommitted_series_handler import UncommittedSeriesHandler
 from custom_data import CustomData
 from s3zip_logging import get_logger
 
+try:
+    from botocore import exceptions as botocore_exceptions
+except ImportError:
+    botocore_exceptions = None
+
 logger = get_logger(__name__)
+
+DEFAULT_S3_RETRIEVAL_MAX_ATTEMPTS = 3
+DEFAULT_S3_RETRIEVAL_RETRY_BASE_DELAY_SECONDS = 0.5
+DEFAULT_S3_RETRIEVAL_RETRY_MAX_DELAY_SECONDS = 5.0
+
+_TRANSIENT_CLIENT_ERROR_CODES = {
+    "InternalError",
+    "InternalFailure",
+    "RequestTimeout",
+    "RequestTimeoutException",
+    "ServiceUnavailable",
+    "SlowDown",
+    "ThrottledException",
+    "Throttling",
+    "ThrottlingException",
+    "TooManyRequestsException",
+}
+
+_PERMANENT_CLIENT_ERROR_CODES = {
+    "AccessDenied",
+    "InvalidAccessKeyId",
+    "InvalidObjectState",
+    "NoSuchBucket",
+    "NoSuchKey",
+    "SignatureDoesNotMatch",
+}
+
+_TRANSIENT_HTTP_STATUS_CODES = {408, 429, 500, 502, 503, 504}
+
+if botocore_exceptions is not None:
+    ClientError = getattr(botocore_exceptions, "ClientError", None)
+    _TRANSIENT_BOTOCORE_EXCEPTIONS = tuple(
+        getattr(botocore_exceptions, name)
+        for name in (
+            "ConnectionClosedError",
+            "ConnectTimeoutError",
+            "EndpointConnectionError",
+            "ProxyConnectionError",
+            "ReadTimeoutError",
+        )
+        if hasattr(botocore_exceptions, name)
+    )
+else:
+    ClientError = None
+    _TRANSIENT_BOTOCORE_EXCEPTIONS = ()
 
 
 class SeriesS3Info:
@@ -39,12 +91,14 @@ class LocalToS3ZipManager:
         _condition: threading.Condition
         _ref_count: int
         _downloaded: bool
+        _failed_exception: Optional[BaseException]
 
         def __init__(self, series_id: str):
             self.series_id = series_id
             self._condition = threading.Condition()
             self._ref_count = 0
             self._downloaded = False
+            self._failed_exception = None
             logger.debug("ZipRetrieval created", series_id=series_id)
 
         def __enter__(self):
@@ -70,17 +124,34 @@ class LocalToS3ZipManager:
         def downloaded(self):
             return self._downloaded
 
+        @property
+        def failed_exception(self):
+            return self._failed_exception
+
         def set_downloaded(self):
             logger.debug("ZipRetrieval set_downloaded, notifying waiters",
                          series_id=self.series_id)
             self._downloaded = True
             self._condition.notify_all()
 
+        def set_failed(self, exc: BaseException):
+            logger.debug("ZipRetrieval set_failed, notifying waiters",
+                         series_id=self.series_id,
+                         error_type=type(exc).__name__,
+                         error=str(exc))
+            self._failed_exception = exc
+            self._condition.notify_all()
+
+        def raise_if_failed(self):
+            if self._failed_exception is not None:
+                raise self._failed_exception
+
         def wait_downloaded(self):
             logger.debug("ZipRetrieval waiting for download to complete",
                          series_id=self.series_id)
-            while not self._downloaded:
+            while not self._downloaded and self._failed_exception is None:
                 self._condition.wait()
+            self.raise_if_failed()
             logger.debug("ZipRetrieval download wait completed",
                          series_id=self.series_id)
 
@@ -93,13 +164,28 @@ class LocalToS3ZipManager:
     _copy_thread: threading.Thread
     _threads_should_stop: bool
     _zip_compression: int
+    _s3_retrieval_max_attempts: int
+    _s3_retrieval_retry_base_delay_sec: float
+    _s3_retrieval_retry_max_delay_sec: float
 
-    def __init__(self, s3_client: S3Client, bucket_name: str, local_storage: LocalStorageInterface, enable_compression: bool, uncommitted_series_handler: UncommittedSeriesHandler, key_prefix: str = ""):
+    def __init__(self,
+                 s3_client: S3Client,
+                 bucket_name: str,
+                 local_storage: LocalStorageInterface,
+                 enable_compression: bool,
+                 uncommitted_series_handler: UncommittedSeriesHandler,
+                 key_prefix: str = "",
+                 s3_retrieval_max_attempts: int = DEFAULT_S3_RETRIEVAL_MAX_ATTEMPTS,
+                 s3_retrieval_retry_base_delay_sec: float = DEFAULT_S3_RETRIEVAL_RETRY_BASE_DELAY_SECONDS,
+                 s3_retrieval_retry_max_delay_sec: float = DEFAULT_S3_RETRIEVAL_RETRY_MAX_DELAY_SECONDS):
         self._s3_client = s3_client
         self._bucket_name = bucket_name
         self._local_storage = local_storage
         self._uncommitted_series_handler = uncommitted_series_handler
         self._key_prefix = key_prefix.strip('/')
+        self._s3_retrieval_max_attempts = max(1, int(s3_retrieval_max_attempts))
+        self._s3_retrieval_retry_base_delay_sec = max(0.0, float(s3_retrieval_retry_base_delay_sec))
+        self._s3_retrieval_retry_max_delay_sec = max(0.0, float(s3_retrieval_retry_max_delay_sec))
         if enable_compression:
             self._zip_compression = zipfile.ZIP_DEFLATED
         else:
@@ -113,7 +199,10 @@ class LocalToS3ZipManager:
         logger.debug("LocalToS3ZipManager initialized",
                      bucket=bucket_name,
                      compression=compression_name,
-                     key_prefix=self._key_prefix or "<none>")
+                     key_prefix=self._key_prefix or "<none>",
+                     s3_retrieval_max_attempts=self._s3_retrieval_max_attempts,
+                     s3_retrieval_retry_base_delay_sec=self._s3_retrieval_retry_base_delay_sec,
+                     s3_retrieval_retry_max_delay_sec=self._s3_retrieval_retry_max_delay_sec)
 
 
     def start(self):
@@ -202,110 +291,106 @@ class LocalToS3ZipManager:
                          tmp_path=tmp_zip.name,
                          attachment_count=len(attachments_uuids))
 
-            with zipfile.ZipFile(tmp_zip.name, "w", compression=self._zip_compression) as zipf:
-                for idx, a_uuid in enumerate(attachments_uuids):
-                    if not local_series_folder: # they all share the same folder
-                        local_series_folder = CustomData.from_orthanc_attachment(a_uuid).local_series_folder
-                        logger.debug("resolved local_series_folder from first attachment",
+            with ExitStack() as local_folder_lease:
+                with zipfile.ZipFile(tmp_zip.name, "w", compression=self._zip_compression) as zipf:
+                    for idx, a_uuid in enumerate(attachments_uuids):
+                        if not local_series_folder: # they all share the same folder
+                            local_series_folder = CustomData.from_orthanc_attachment(a_uuid).local_series_folder
+                            local_folder_lease.enter_context(self._local_storage.lease_folder(local_series_folder))
+                            logger.debug("resolved local_series_folder from first attachment",
+                                         series_id=series_id,
+                                         local_series_folder=local_series_folder)
+                        content = self._local_storage.read_file(uuid=a_uuid,
+                                                                local_series_folder=local_series_folder)
+                        total_uncompressed_bytes += len(content)
+                        logger.debug("adding attachment to zip",
                                      series_id=series_id,
-                                     local_series_folder=local_series_folder)
-                    content = self._local_storage.read_file(uuid=a_uuid,
-                                                            local_series_folder=local_series_folder)
-                    total_uncompressed_bytes += len(content)
-                    logger.debug("adding attachment to zip",
+                                     uuid=a_uuid,
+                                     index=idx,
+                                     size_bytes=len(content))
+                        zipf.writestr(a_uuid, content)
+                        logger.debug("attachment added to zip",
+                                     series_id=series_id,
+                                     uuid=a_uuid,
+                                     index=idx)
+
+                t_zip_done = time.monotonic()
+                zip_size_bytes = os.path.getsize(tmp_zip.name)
+
+                logger.info("zip archive built",
+                            series_id=series_id,
+                            attachment_count=len(attachments_uuids),
+                            zip_size_bytes=zip_size_bytes,
+                            uncompressed_bytes=total_uncompressed_bytes,
+                            zip_build_ms=int((t_zip_done - t0) * 1000))
+
+                # Upload to S3
+                s3_key = self._get_series_s3_key(series_id)
+                logger.info("uploading zip to S3",
+                            series_id=series_id,
+                            s3_key=s3_key,
+                            bucket=self._bucket_name,
+                            zip_size_bytes=zip_size_bytes,
+                            uncompressed_bytes=total_uncompressed_bytes)
+                logger.debug("calling s3_client.upload_file()",
+                             series_id=series_id,
+                             s3_key=s3_key,
+                             bucket=self._bucket_name)
+
+                self._s3_client.upload_file(tmp_zip.name, self._bucket_name, s3_key)
+
+                t_upload_done = time.monotonic()
+                logger.debug("s3_client.upload_file() returned",
+                             series_id=series_id,
+                             s3_key=s3_key)
+                logger.info("zip uploaded to S3",
+                            series_id=series_id,
+                            s3_key=s3_key,
+                            bucket=self._bucket_name,
+                            zip_size_bytes=zip_size_bytes,
+                            upload_ms=int((t_upload_done - t_zip_done) * 1000))
+
+                # Update the custom data to notify that the file is now stored in a zip in S3
+                s3_custom_data = CustomData(storage=CustomData.Storage.S3_ZIP,
+                                            local_series_folder=local_series_folder,
+                                            s3_zip_key=s3_key).to_binary()
+
+                logger.info("starting SetAttachmentCustomData loop",
+                            series_id=series_id,
+                            attachment_count=len(attachments_uuids),
+                            s3_key=s3_key)
+                t_meta_start = time.monotonic()
+
+                for idx, a_uuid in enumerate(attachments_uuids):
+                    logger.debug("calling orthanc.SetAttachmentCustomData()",
                                  series_id=series_id,
                                  uuid=a_uuid,
                                  index=idx,
-                                 size_bytes=len(content))
-                    zipf.writestr(a_uuid, content)
-                    logger.debug("attachment added to zip",
+                                 total=len(attachments_uuids))
+                    orthanc.SetAttachmentCustomData(a_uuid, s3_custom_data)
+                    logger.debug("orthanc.SetAttachmentCustomData() returned",
                                  series_id=series_id,
                                  uuid=a_uuid,
                                  index=idx)
 
-            t_zip_done = time.monotonic()
-            zip_size_bytes = os.path.getsize(tmp_zip.name)
+                t_meta_done = time.monotonic()
+                logger.info("SetAttachmentCustomData loop complete",
+                            series_id=series_id,
+                            attachment_count=len(attachments_uuids),
+                            s3_key=s3_key,
+                            metadata_update_ms=int((t_meta_done - t_meta_start) * 1000))
 
-            logger.info("zip archive built",
-                        series_id=series_id,
-                        attachment_count=len(attachments_uuids),
-                        zip_size_bytes=zip_size_bytes,
-                        uncompressed_bytes=total_uncompressed_bytes,
-                        zip_build_ms=int((t_zip_done - t0) * 1000))
-
-            # Upload to S3
-            s3_key = self._get_series_s3_key(series_id)
-            logger.info("uploading zip to S3",
-                        series_id=series_id,
+                # The marker is the eviction guard's durable signal that the
+                # folder contents are recoverable from S3. It is written while
+                # the folder lease is active so eviction cannot remove the
+                # directory between opening the marker and atomically publishing
+                # its final path.
+                if local_series_folder:
+                    self._write_s3_uploaded_marker(
+                        local_series_folder=local_series_folder,
                         s3_key=s3_key,
-                        bucket=self._bucket_name,
-                        zip_size_bytes=zip_size_bytes,
-                        uncompressed_bytes=total_uncompressed_bytes)
-            logger.debug("calling s3_client.upload_file()",
-                         series_id=series_id,
-                         s3_key=s3_key,
-                         bucket=self._bucket_name)
-
-            self._s3_client.upload_file(tmp_zip.name, self._bucket_name, s3_key)
-
-            t_upload_done = time.monotonic()
-            logger.debug("s3_client.upload_file() returned",
-                         series_id=series_id,
-                         s3_key=s3_key)
-            logger.info("zip uploaded to S3",
                         series_id=series_id,
-                        s3_key=s3_key,
-                        bucket=self._bucket_name,
-                        zip_size_bytes=zip_size_bytes,
-                        upload_ms=int((t_upload_done - t_zip_done) * 1000))
-
-            # Update the custom data to notify that the file is now stored in a zip in S3
-            s3_custom_data = CustomData(storage=CustomData.Storage.S3_ZIP,
-                                        local_series_folder=local_series_folder,
-                                        s3_zip_key=s3_key).to_binary()
-
-            logger.info("starting SetAttachmentCustomData loop",
-                        series_id=series_id,
-                        attachment_count=len(attachments_uuids),
-                        s3_key=s3_key)
-            t_meta_start = time.monotonic()
-
-            for idx, a_uuid in enumerate(attachments_uuids):
-                logger.debug("calling orthanc.SetAttachmentCustomData()",
-                             series_id=series_id,
-                             uuid=a_uuid,
-                             index=idx,
-                             total=len(attachments_uuids))
-                orthanc.SetAttachmentCustomData(a_uuid, s3_custom_data)
-                logger.debug("orthanc.SetAttachmentCustomData() returned",
-                             series_id=series_id,
-                             uuid=a_uuid,
-                             index=idx)
-
-            t_meta_done = time.monotonic()
-            logger.info("SetAttachmentCustomData loop complete",
-                        series_id=series_id,
-                        attachment_count=len(attachments_uuids),
-                        s3_key=s3_key,
-                        metadata_update_ms=int((t_meta_done - t_meta_start) * 1000))
-
-            # At this point, the local storage does not need to keep the files stored locally but there is no need to notify it.
-            # In the best scenario, the files will still be stored locally at the time we need it.
-
-            # Write a marker file so the LRU eviction guard knows this folder is safe to evict
-            if local_series_folder:
-                marker_path = os.path.join(
-                    self._local_storage.get_folder_path(local_series_folder),
-                    ".s3-uploaded"
-                )
-                try:
-                    with open(marker_path, "w") as f:
-                        f.write(s3_key)
-                    logger.debug("wrote S3 upload marker file",
-                                 series_id=series_id, marker_path=marker_path)
-                except Exception as e:
-                    logger.warning("failed to write S3 upload marker file",
-                                   series_id=series_id, error=str(e))
+                    )
 
         duration_ms = int((time.monotonic() - t0) * 1000)
 
@@ -322,6 +407,56 @@ class LocalToS3ZipManager:
                     upload_ms=int((t_upload_done - t_zip_done) * 1000),
                     metadata_update_ms=int((t_meta_done - t_meta_start) * 1000),
                     duration_ms=duration_ms)
+
+    def _write_s3_uploaded_marker(self, local_series_folder: str, s3_key: str, series_id: str):
+        folder_path = self._local_storage.get_folder_path(local_series_folder)
+        marker_path = os.path.join(folder_path, ".s3-uploaded")
+        tmp_marker_path = os.path.join(
+            folder_path,
+            f".s3-uploaded.tmp-{os.getpid()}-{threading.get_ident()}"
+        )
+
+        try:
+            os.makedirs(folder_path, exist_ok=True)
+            with open(tmp_marker_path, "w") as f:
+                f.write(s3_key)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_marker_path, marker_path)
+            self._fsync_directory_if_supported(folder_path)
+            logger.debug("wrote S3 upload marker file",
+                         series_id=series_id,
+                         marker_path=marker_path,
+                         s3_key=s3_key)
+        except Exception as e:
+            try:
+                if os.path.exists(tmp_marker_path):
+                    os.remove(tmp_marker_path)
+            except Exception as cleanup_error:
+                logger.warning("failed to remove temporary S3 upload marker",
+                               series_id=series_id,
+                               tmp_marker_path=tmp_marker_path,
+                               error=str(cleanup_error))
+            logger.warning("failed to write S3 upload marker file",
+                           series_id=series_id,
+                           marker_path=marker_path,
+                           error=str(e))
+
+    def _fsync_directory_if_supported(self, folder_path: str):
+        if not hasattr(os, "O_DIRECTORY"):
+            return
+
+        directory_fd = None
+        try:
+            directory_fd = os.open(folder_path, os.O_RDONLY | os.O_DIRECTORY)
+            os.fsync(directory_fd)
+        except OSError as e:
+            logger.debug("directory fsync after marker write failed",
+                         folder_path=folder_path,
+                         error=str(e))
+        finally:
+            if directory_fd is not None:
+                os.close(directory_fd)
 
     def _acquire_zip_retrieval(self, s3_zip_key: str) -> Tuple[ZipRetrieval, bool]:
         """Return the active retrieval object with a counted live reference.
@@ -387,11 +522,17 @@ class LocalToS3ZipManager:
             # it until the extraction and all waiters have left this retrieval.
             with self._local_storage.lease_folder(local_series_folder):
                 with zip_retrieval: # the first thread to get here keeps the condition "locked" during the zip retrieval
+                    zip_retrieval.raise_if_failed()
                     if not zip_retrieval.downloaded:
                         logger.debug("this thread will perform the S3 download",
                                      s3_zip_key=s3_zip_key)
-                        self._retrieve_zip_from_s3(s3_zip_key, local_series_folder)
-                        zip_retrieval.set_downloaded()
+                        try:
+                            self._retrieve_zip_from_s3(s3_zip_key, local_series_folder)
+                        except Exception as e:
+                            zip_retrieval.set_failed(e)
+                            raise
+                        else:
+                            zip_retrieval.set_downloaded()
                     else:
                         logger.debug("another thread already downloaded this zip, waiting",
                                      s3_zip_key=s3_zip_key)
@@ -401,10 +542,54 @@ class LocalToS3ZipManager:
 
 
     def _retrieve_zip_from_s3(self, s3_zip_key: str, local_series_folder: str):
+        started_at = time.monotonic()
+        for attempt in range(1, self._s3_retrieval_max_attempts + 1):
+            try:
+                return self._retrieve_zip_from_s3_once(
+                    s3_zip_key=s3_zip_key,
+                    local_series_folder=local_series_folder,
+                    attempt=attempt,
+                )
+            except Exception as e:
+                retryable = self._is_retryable_s3_retrieval_exception(e)
+                is_last_attempt = attempt >= self._s3_retrieval_max_attempts
+                if not retryable or is_last_attempt:
+                    logger.error(
+                        "series retrieval from S3 failed",
+                        s3_zip_key=s3_zip_key,
+                        bucket=self._bucket_name,
+                        local_series_folder=local_series_folder,
+                        attempt=attempt,
+                        max_attempts=self._s3_retrieval_max_attempts,
+                        retryable=retryable,
+                        error_type=type(e).__name__,
+                        error=str(e),
+                        elapsed_ms=int((time.monotonic() - started_at) * 1000),
+                    )
+                    raise
+
+                delay_sec = self._get_s3_retrieval_retry_delay_sec(attempt)
+                logger.warning(
+                    "series retrieval from S3 failed, retrying",
+                    s3_zip_key=s3_zip_key,
+                    bucket=self._bucket_name,
+                    local_series_folder=local_series_folder,
+                    attempt=attempt,
+                    max_attempts=self._s3_retrieval_max_attempts,
+                    retry_delay_ms=int(delay_sec * 1000),
+                    error_type=type(e).__name__,
+                    error=str(e),
+                )
+                if delay_sec > 0:
+                    time.sleep(delay_sec)
+
+    def _retrieve_zip_from_s3_once(self, s3_zip_key: str, local_series_folder: str, attempt: int):
         logger.info("series retrieval from S3 starting",
                     s3_zip_key=s3_zip_key,
                     bucket=self._bucket_name,
-                    local_series_folder=local_series_folder)
+                    local_series_folder=local_series_folder,
+                    attempt=attempt,
+                    max_attempts=self._s3_retrieval_max_attempts)
         t0 = time.monotonic()
 
         file_count = 0
@@ -460,11 +645,46 @@ class LocalToS3ZipManager:
                     s3_zip_key=s3_zip_key,
                     bucket=self._bucket_name,
                     local_series_folder=local_series_folder,
+                    attempt=attempt,
                     file_count=file_count,
                     zip_size_bytes=zip_size_bytes,
                     uncompressed_bytes=total_bytes,
                     download_ms=int((t_download_done - t0) * 1000),
                     duration_ms=duration_ms)
+
+    def _get_s3_retrieval_retry_delay_sec(self, failed_attempt: int) -> float:
+        if self._s3_retrieval_retry_base_delay_sec <= 0:
+            return 0.0
+
+        exponential_delay = self._s3_retrieval_retry_base_delay_sec * (2 ** max(0, failed_attempt - 1))
+        capped_delay = min(exponential_delay, self._s3_retrieval_retry_max_delay_sec)
+        return random.uniform(0.0, capped_delay)
+
+    def _is_retryable_s3_retrieval_exception(self, exc: BaseException) -> bool:
+        if isinstance(exc, zipfile.BadZipFile):
+            return False
+
+        if ClientError is not None and isinstance(exc, ClientError):
+            response = getattr(exc, "response", {}) or {}
+            error = response.get("Error", {}) or {}
+            metadata = response.get("ResponseMetadata", {}) or {}
+            error_code = error.get("Code")
+            http_status_code = metadata.get("HTTPStatusCode")
+            if error_code in _PERMANENT_CLIENT_ERROR_CODES:
+                return False
+            if error_code in _TRANSIENT_CLIENT_ERROR_CODES:
+                return True
+            if http_status_code in _TRANSIENT_HTTP_STATUS_CODES:
+                return True
+            return False
+
+        if _TRANSIENT_BOTOCORE_EXCEPTIONS and isinstance(exc, _TRANSIENT_BOTOCORE_EXCEPTIONS):
+            return True
+
+        if isinstance(exc, (ConnectionError, TimeoutError)):
+            return True
+
+        return False
 
 
     def _get_instances_attachments(self, series_id: str) -> List[str]:

--- a/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
+++ b/docker/python-s3-zip/plugin/local_to_s3_zip_manager.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 import threading
 import time
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Tuple
 from boto3 import client as S3Client
 from local_storage_interface import LocalStorageInterface
 from uncommitted_series_handler import UncommittedSeriesHandler
@@ -38,37 +38,30 @@ class LocalToS3ZipManager:
         series_id: str
         _condition: threading.Condition
         _ref_count: int
-        _manager: 'LocalToS3ZipManager'
         _downloaded: bool
 
-        def __init__(self, series_id: str, manager: 'LocalToS3ZipManager'):
+        def __init__(self, series_id: str):
             self.series_id = series_id
             self._condition = threading.Condition()
             self._ref_count = 0
-            self._manager = manager
             self._downloaded = False
             logger.debug("ZipRetrieval created", series_id=series_id)
 
         def __enter__(self):
             logger.debug("ZipRetrieval entering (acquiring condition)",
                          series_id=self.series_id,
-                         ref_count=self._ref_count + 1)
-            self._ref_count += 1
+                         ref_count=self._ref_count)
             self._condition.__enter__()
             logger.debug("ZipRetrieval entered (condition acquired)",
                          series_id=self.series_id,
                          ref_count=self._ref_count)
+            return self
 
         def __exit__(self, exc_type, exc_val, exc_tb):
             logger.debug("ZipRetrieval exiting",
                          series_id=self.series_id,
                          ref_count=self._ref_count)
-            self._ref_count -= 1
             self._condition.__exit__(exc_type, exc_val, exc_tb)
-            if self._ref_count == 0:
-                logger.debug("ZipRetrieval ref_count reached 0, discarding",
-                             series_id=self.series_id)
-                self._manager._discard_zip_retrieval(self.series_id)
             logger.debug("ZipRetrieval exited",
                          series_id=self.series_id,
                          ref_count=self._ref_count)
@@ -330,10 +323,42 @@ class LocalToS3ZipManager:
                     metadata_update_ms=int((t_meta_done - t_meta_start) * 1000),
                     duration_ms=duration_ms)
 
-    def _discard_zip_retrieval(self, series_id: str):
+    def _acquire_zip_retrieval(self, s3_zip_key: str) -> Tuple[ZipRetrieval, bool]:
+        """Return the active retrieval object with a counted live reference.
+
+        Lookup/create and refcount increment share the same lock. A thread must
+        not leave this method with an uncounted object: if another thread
+        completes the retrieval before this caller enters the condition, the
+        active dictionary entry still has to stay alive for this caller.
+        """
         with self._s3_zip_retrievals_lock:
-            del self._s3_zip_retrievals[series_id]
-            logger.debug("discarded ZipRetrieval", s3_zip_key=series_id)
+            is_new_retrieval = False
+            if s3_zip_key not in self._s3_zip_retrievals:
+                self._s3_zip_retrievals[s3_zip_key] = LocalToS3ZipManager.ZipRetrieval(s3_zip_key)
+                is_new_retrieval = True
+            zip_retrieval = self._s3_zip_retrievals[s3_zip_key]
+            zip_retrieval._ref_count += 1
+            logger.debug("acquired ZipRetrieval",
+                         s3_zip_key=s3_zip_key,
+                         ref_count=zip_retrieval._ref_count,
+                         is_new_retrieval=is_new_retrieval)
+            return zip_retrieval, is_new_retrieval
+
+
+    def _release_zip_retrieval(self, zip_retrieval: ZipRetrieval):
+        """Release a counted retrieval reference and discard it when idle."""
+        with self._s3_zip_retrievals_lock:
+            zip_retrieval._ref_count -= 1
+            logger.debug("released ZipRetrieval",
+                         s3_zip_key=zip_retrieval.series_id,
+                         ref_count=zip_retrieval._ref_count)
+            if zip_retrieval._ref_count == 0:
+                if self._s3_zip_retrievals.get(zip_retrieval.series_id) is zip_retrieval:
+                    del self._s3_zip_retrievals[zip_retrieval.series_id]
+                    logger.debug("discarded ZipRetrieval", s3_zip_key=zip_retrieval.series_id)
+                else:
+                    logger.warning("ZipRetrieval release found a different active retrieval",
+                                   s3_zip_key=zip_retrieval.series_id)
 
 
     def get_s3_zip_stream(self, series_id: str):  # returns a stream
@@ -349,28 +374,30 @@ class LocalToS3ZipManager:
 
     def retrieve_zip_from_s3(self, s3_zip_key: str, local_series_folder: str):
         # make sure we do not retrieve the same file multiple times at the same time
-        is_new_retrieval = False
-        with self._s3_zip_retrievals_lock:  # global lock to safely manipulate the retrieval dict
-            if s3_zip_key not in self._s3_zip_retrievals:
-                self._s3_zip_retrievals[s3_zip_key] = LocalToS3ZipManager.ZipRetrieval(s3_zip_key, manager=self)
-                is_new_retrieval = True
-            zip_retrieval = self._s3_zip_retrievals[s3_zip_key]
+        zip_retrieval, is_new_retrieval = self._acquire_zip_retrieval(s3_zip_key)
 
         logger.debug("retrieve_zip_from_s3 entered",
                      s3_zip_key=s3_zip_key,
                      local_series_folder=local_series_folder,
                      is_new_retrieval=is_new_retrieval)
 
-        with zip_retrieval: # the first thread to get here keeps the condition "locked" during the zip retrieval
-            if not zip_retrieval.downloaded:
-                logger.debug("this thread will perform the S3 download",
-                             s3_zip_key=s3_zip_key)
-                self._retrieve_zip_from_s3(s3_zip_key, local_series_folder)
-                zip_retrieval.set_downloaded()
-            else:
-                logger.debug("another thread already downloaded this zip, waiting",
-                             s3_zip_key=s3_zip_key)
-                zip_retrieval.wait_downloaded()
+        try:
+            # The zip is extracted as several file writes. A folder may already
+            # contain an S3 marker from an earlier upload, so eviction must skip
+            # it until the extraction and all waiters have left this retrieval.
+            with self._local_storage.lease_folder(local_series_folder):
+                with zip_retrieval: # the first thread to get here keeps the condition "locked" during the zip retrieval
+                    if not zip_retrieval.downloaded:
+                        logger.debug("this thread will perform the S3 download",
+                                     s3_zip_key=s3_zip_key)
+                        self._retrieve_zip_from_s3(s3_zip_key, local_series_folder)
+                        zip_retrieval.set_downloaded()
+                    else:
+                        logger.debug("another thread already downloaded this zip, waiting",
+                                     s3_zip_key=s3_zip_key)
+                        zip_retrieval.wait_downloaded()
+        finally:
+            self._release_zip_retrieval(zip_retrieval)
 
 
     def _retrieve_zip_from_s3(self, s3_zip_key: str, local_series_folder: str):
@@ -492,4 +519,3 @@ class LocalToS3ZipManager:
                 status.s3_zip_key = cd.s3_zip_key
 
         return status
-

--- a/docker/python-s3-zip/plugin/s3_zip_storage.py
+++ b/docker/python-s3-zip/plugin/s3_zip_storage.py
@@ -5,7 +5,13 @@ from helpers import Helpers
 from typing import Optional, Tuple
 from boto3 import client as S3Client
 from local_storage import LocalStorage
-from local_to_s3_zip_manager import LocalToS3ZipManager, SeriesS3Info
+from local_to_s3_zip_manager import (
+    DEFAULT_S3_RETRIEVAL_MAX_ATTEMPTS,
+    DEFAULT_S3_RETRIEVAL_RETRY_BASE_DELAY_SECONDS,
+    DEFAULT_S3_RETRIEVAL_RETRY_MAX_DELAY_SECONDS,
+    LocalToS3ZipManager,
+    SeriesS3Info,
+)
 from uncommitted_series_handler import UncommittedSeriesHandler
 from custom_data import CustomData
 from s3zip_logging import get_logger
@@ -19,13 +25,25 @@ class S3ZipStorage:
     _zip_manager: LocalToS3ZipManager
     _uncommitted_series_handler: UncommittedSeriesHandler
 
-    def __init__(self, temporary_folder_root: str, temp_folder_max_size_mb: int, s3_client: S3Client, bucket_name: str, enable_compression: bool, key_prefix: str = ""):
+    def __init__(self,
+                 temporary_folder_root: str,
+                 temp_folder_max_size_mb: int,
+                 s3_client: S3Client,
+                 bucket_name: str,
+                 enable_compression: bool,
+                 key_prefix: str = "",
+                 s3_retrieval_max_attempts: int = DEFAULT_S3_RETRIEVAL_MAX_ATTEMPTS,
+                 s3_retrieval_retry_base_delay_sec: float = DEFAULT_S3_RETRIEVAL_RETRY_BASE_DELAY_SECONDS,
+                 s3_retrieval_retry_max_delay_sec: float = DEFAULT_S3_RETRIEVAL_RETRY_MAX_DELAY_SECONDS):
         logger.debug("initializing S3ZipStorage",
                      temp_folder=temporary_folder_root,
                      max_size_mb=temp_folder_max_size_mb,
                      bucket=bucket_name,
                      compression=enable_compression,
-                     key_prefix=key_prefix or "<none>")
+                     key_prefix=key_prefix or "<none>",
+                     s3_retrieval_max_attempts=s3_retrieval_max_attempts,
+                     s3_retrieval_retry_base_delay_sec=s3_retrieval_retry_base_delay_sec,
+                     s3_retrieval_retry_max_delay_sec=s3_retrieval_retry_max_delay_sec)
 
         self._uncommitted_series_handler = UncommittedSeriesHandler()
 
@@ -37,7 +55,10 @@ class S3ZipStorage:
                                                 local_storage=self._local_storage,
                                                 enable_compression=enable_compression,
                                                 uncommitted_series_handler=self._uncommitted_series_handler,
-                                                key_prefix=key_prefix)
+                                                key_prefix=key_prefix,
+                                                s3_retrieval_max_attempts=s3_retrieval_max_attempts,
+                                                s3_retrieval_retry_base_delay_sec=s3_retrieval_retry_base_delay_sec,
+                                                s3_retrieval_retry_max_delay_sec=s3_retrieval_retry_max_delay_sec)
 
         # Set up the eviction guard: a folder is safe to evict only if it has the
         # .s3-uploaded marker file written by the copy thread after a successful S3 upload.
@@ -144,7 +165,7 @@ class S3ZipStorage:
                      range_start=range_start,
                      size=size)
 
-        cd = CustomData.from_binary(custom_data)
+        cd: CustomData = CustomData.from_binary(custom_data)
 
         logger.debug("storage_read_range called",
                      uuid=uuid,

--- a/docker/python-s3-zip/plugin/s3_zip_storage.py
+++ b/docker/python-s3-zip/plugin/s3_zip_storage.py
@@ -141,6 +141,13 @@ class S3ZipStorage:
                                                 content=content)
         logger.debug("local_storage.create() returned", uuid=uuid, error_code=str(error_code))
 
+        # Any new file invalidates "everything in this folder is on S3". Wipe
+        # the marker so eviction cannot purge the folder before the next copy
+        # captures this instance. A racing concurrent copy that recheck-skips
+        # its own marker write keeps the invariant intact. Idempotent on a
+        # missing marker, so safe to call even when create() failed.
+        _ = self._zip_manager.invalidate_s3_uploaded_marker(series_hash)
+
         custom_data = CustomData(CustomData.Storage.LOCAL, local_series_folder=series_hash)
 
         logger.debug("storage_create completed",

--- a/docker/python-s3-zip/plugin/s3_zip_storage.py
+++ b/docker/python-s3-zip/plugin/s3_zip_storage.py
@@ -143,10 +143,14 @@ class S3ZipStorage:
 
         # Any new file invalidates "everything in this folder is on S3". Wipe
         # the marker so eviction cannot purge the folder before the next copy
-        # captures this instance. A racing concurrent copy that recheck-skips
-        # its own marker write keeps the invariant intact. Idempotent on a
-        # missing marker, so safe to call even when create() failed.
-        _ = self._zip_manager.invalidate_s3_uploaded_marker(series_hash)
+        # captures this instance. The per-folder critical section pairs with
+        # the matching one in copy_series_to_s3 around its recheck+marker
+        # write: ordering between the two is now sequential, so a stale
+        # marker cannot be published after this invalidate runs as a no-op.
+        # Idempotent on a missing marker, so safe to call even when create()
+        # failed.
+        with self._local_storage.folder_marker_critical_section(series_hash):
+            _ = self._zip_manager.invalidate_s3_uploaded_marker(local_series_folder=series_hash)
 
         custom_data = CustomData(CustomData.Storage.LOCAL, local_series_folder=series_hash)
 

--- a/docker/python-s3-zip/plugin/s3_zip_storage.py
+++ b/docker/python-s3-zip/plugin/s3_zip_storage.py
@@ -155,69 +155,67 @@ class S3ZipStorage:
                      local_series_folder=cd.local_series_folder,
                      s3_zip_key=cd.s3_zip_key or "<none>")
 
-        # TODO: implement a LocalFileLocker with __enter__ & __exit__ to make sure the file is not deleted in the meantime
-        logger.debug("calling local_storage.has_local_file()", uuid=uuid)
-        has_local = self._local_storage.has_local_file(uuid=uuid,
-                                                       local_series_folder=cd.local_series_folder,
-                                                       content_type=content_type)
-        logger.debug("local_storage.has_local_file() returned", uuid=uuid, has_local=has_local)
+        # Eviction removes whole series folders. Keep the folder leased from the
+        # local existence check through the final read so a safe-to-evict folder
+        # cannot disappear between `has_local_file()` and `read_range()`.
+        with self._local_storage.lease_folder(cd.local_series_folder):
+            logger.debug("calling local_storage.has_local_file()", uuid=uuid)
+            has_local = self._local_storage.has_local_file(uuid=uuid,
+                                                           local_series_folder=cd.local_series_folder,
+                                                           content_type=content_type)
+            logger.debug("local_storage.has_local_file() returned", uuid=uuid, has_local=has_local)
 
-        if not has_local:
-            s3_zip_key = cd.s3_zip_key
+            if not has_local:
+                s3_zip_key = cd.s3_zip_key
 
-            if s3_zip_key is None:
-                # The custom data says "local" but the file is gone (pod restart with
-                # ephemeral storage, or LRU eviction before S3 upload).
-                # Try to recover by checking if a marker file left by the S3 copy thread
-                # tells us the S3 key.
-                marker_path = os.path.join(
-                    self._local_storage.get_folder_path(cd.local_series_folder),
-                    ".s3-uploaded"
-                )
-                if os.path.exists(marker_path):
-                    with open(marker_path, "r") as f:
-                        s3_zip_key = f.read().strip()
-                    logger.warning(
-                        "instance marked as local but file is gone; recovered S3 key from marker",
-                        uuid=uuid,
-                        s3_zip_key=s3_zip_key,
-                        local_series_folder=cd.local_series_folder)
-                else:
-                    logger.error(
-                        "instance marked as local but file is gone and no S3 key available. "
-                        "DATA LOSS: this instance cannot be retrieved.",
-                        uuid=uuid,
-                        local_series_folder=cd.local_series_folder)
-                    return orthanc.ErrorCode.UNKNOWN_RESOURCE, None
+                if s3_zip_key is None:
+                    # Custom data can still point to local storage after a pod restart
+                    # or cache eviction. A completed upload leaves a marker in the
+                    # series folder so reads can recover the S3 key without querying
+                    # every instance attachment again.
+                    marker_path = os.path.join(
+                        self._local_storage.get_folder_path(cd.local_series_folder),
+                        ".s3-uploaded"
+                    )
+                    if os.path.exists(marker_path):
+                        with open(marker_path, "r") as f:
+                            s3_zip_key = f.read().strip()
+                        logger.warning(
+                            "instance marked as local but file is gone; recovered S3 key from marker",
+                            uuid=uuid,
+                            s3_zip_key=s3_zip_key,
+                            local_series_folder=cd.local_series_folder)
+                    else:
+                        logger.error(
+                            "instance marked as local but file is gone and no S3 key available. "
+                            "DATA LOSS: this instance cannot be retrieved.",
+                            uuid=uuid,
+                            local_series_folder=cd.local_series_folder)
+                        return orthanc.ErrorCode.UNKNOWN_RESOURCE, None
 
-            logger.debug("instance not in local cache, retrieving series from S3",
-                         uuid=uuid,
-                         s3_zip_key=s3_zip_key,
-                         local_series_folder=cd.local_series_folder)
-            logger.debug("calling zip_manager.retrieve_zip_from_s3()", uuid=uuid, s3_zip_key=s3_zip_key)
-            self._zip_manager.retrieve_zip_from_s3(s3_zip_key=s3_zip_key,
-                                                   local_series_folder=cd.local_series_folder)
-            logger.debug("zip_manager.retrieve_zip_from_s3() returned", uuid=uuid)
-            logger.debug("series retrieved from S3 into local cache",
-                         uuid=uuid,
-                         s3_zip_key=s3_zip_key)
-        else:
-            logger.debug("instance found in local cache",
-                         uuid=uuid,
-                         local_series_folder=cd.local_series_folder)
+                logger.debug("instance not in local cache, retrieving series from S3",
+                             uuid=uuid,
+                             s3_zip_key=s3_zip_key,
+                             local_series_folder=cd.local_series_folder)
+                logger.debug("calling zip_manager.retrieve_zip_from_s3()", uuid=uuid, s3_zip_key=s3_zip_key)
+                self._zip_manager.retrieve_zip_from_s3(s3_zip_key=s3_zip_key,
+                                                       local_series_folder=cd.local_series_folder)
+                logger.debug("zip_manager.retrieve_zip_from_s3() returned", uuid=uuid)
+                logger.debug("series retrieved from S3 into local cache",
+                             uuid=uuid,
+                             s3_zip_key=s3_zip_key)
+            else:
+                logger.debug("instance found in local cache",
+                             uuid=uuid,
+                             local_series_folder=cd.local_series_folder)
 
-        # make sure the file is in the local storage (this is a blocking call)
-        # TODO
-
-        # if custom_data and len(custom_data):
-        #     custom_data = json.loads(custom_data.decode('utf-8'))
-        logger.debug("calling local_storage.read_range()", uuid=uuid, range_start=range_start, size=size)
-        result = self._local_storage.read_range(uuid=uuid,
-                                                local_series_folder=cd.local_series_folder,
-                                                content_type=content_type,
-                                                range_start=range_start,
-                                                size=size)
-        logger.debug("local_storage.read_range() returned", uuid=uuid)
+            logger.debug("calling local_storage.read_range()", uuid=uuid, range_start=range_start, size=size)
+            result = self._local_storage.read_range(uuid=uuid,
+                                                    local_series_folder=cd.local_series_folder,
+                                                    content_type=content_type,
+                                                    range_start=range_start,
+                                                    size=size)
+            logger.debug("local_storage.read_range() returned", uuid=uuid)
 
         error_code, data = result
         logger.debug("storage_read_range completed",

--- a/docker/python-s3-zip/plugin/s3_zip_storage_plugin.py
+++ b/docker/python-s3-zip/plugin/s3_zip_storage_plugin.py
@@ -17,6 +17,7 @@ logger.debug("s3_zip_storage_plugin module loaded")
 
 storage_singleton: Optional[S3ZipStorage] = None
 
+DEFAULT_MAX_LOCAL_STORAGE_SIZE_MB: float = 30720
 
 def _storage_create(uuid: str,
                     content_type: orthanc.ContentType,
@@ -135,7 +136,7 @@ def on_rest_api_series_s3_status(output, uri, **request):  # GET -> returns a st
             logger.error("Failed to retrieve series status", series_id)
             output.SendHttpStatusCode(400)
             return
-        
+
         status = {
             'is-stored-in-s3': series_status.is_stored_in_s3,
             's3-zip-key': series_status.s3_zip_key
@@ -162,7 +163,7 @@ def on_rest_api_series_s3_archive(output, uri, **request): # GET -> streams a zi
             while True:
                 chunk = zip_stream.read(64*1024)
                 if not chunk:
-                    return                
+                    return
 
                 output.SendStreamChunk(chunk)
         else:
@@ -343,7 +344,7 @@ def register_s3_zip_storage_plugin():
     if "LocalStorageMaxSizeMB" in s3_zip_config:
         max_local_storage_size_mb = int(s3_zip_config.get("LocalStorageMaxSizeMB"))
     else:
-        max_local_storage_size_mb = 1024
+        max_local_storage_size_mb = DEFAULT_MAX_LOCAL_STORAGE_SIZE_MB
     logger.debug("compression setting resolved", enable_compression=enable_compression)
 
     key_prefix = s3_zip_config.get("PrefixKey", "").strip('/')

--- a/docker/python-s3-zip/plugin/s3_zip_storage_plugin.py
+++ b/docker/python-s3-zip/plugin/s3_zip_storage_plugin.py
@@ -6,6 +6,11 @@ import boto3
 import uuid as uuid_module
 from typing import Tuple, Optional
 from s3_zip_storage import S3ZipStorage
+from local_to_s3_zip_manager import (
+    DEFAULT_S3_RETRIEVAL_MAX_ATTEMPTS,
+    DEFAULT_S3_RETRIEVAL_RETRY_BASE_DELAY_SECONDS,
+    DEFAULT_S3_RETRIEVAL_RETRY_MAX_DELAY_SECONDS,
+)
 from s3zip_logging import get_logger
 
 # This file contains a wrapper to facilitate the installation of the S3ZipStorage.
@@ -345,7 +350,28 @@ def register_s3_zip_storage_plugin():
         max_local_storage_size_mb = int(s3_zip_config.get("LocalStorageMaxSizeMB"))
     else:
         max_local_storage_size_mb = DEFAULT_MAX_LOCAL_STORAGE_SIZE_MB
+
+    s3_retrieval_max_attempts = int(
+        s3_zip_config.get("S3RetrievalMaxAttempts", DEFAULT_S3_RETRIEVAL_MAX_ATTEMPTS)
+    )
+    s3_retrieval_retry_base_delay_sec = float(
+        s3_zip_config.get(
+            "S3RetrievalRetryBaseDelaySeconds",
+            DEFAULT_S3_RETRIEVAL_RETRY_BASE_DELAY_SECONDS,
+        )
+    )
+    s3_retrieval_retry_max_delay_sec = float(
+        s3_zip_config.get(
+            "S3RetrievalRetryMaxDelaySeconds",
+            DEFAULT_S3_RETRIEVAL_RETRY_MAX_DELAY_SECONDS,
+        )
+    )
+
     logger.debug("compression setting resolved", enable_compression=enable_compression)
+    logger.debug("S3 retrieval retry settings resolved",
+                 s3_retrieval_max_attempts=s3_retrieval_max_attempts,
+                 s3_retrieval_retry_base_delay_sec=s3_retrieval_retry_base_delay_sec,
+                 s3_retrieval_retry_max_delay_sec=s3_retrieval_retry_max_delay_sec)
 
     key_prefix = s3_zip_config.get("PrefixKey", "").strip('/')
     logger.debug("key prefix resolved", key_prefix=key_prefix or "<none>")
@@ -355,7 +381,10 @@ def register_s3_zip_storage_plugin():
                                      s3_client=s3_client,
                                      bucket_name=bucket_name,
                                      enable_compression=enable_compression,
-                                     key_prefix=key_prefix)
+                                     key_prefix=key_prefix,
+                                     s3_retrieval_max_attempts=s3_retrieval_max_attempts,
+                                     s3_retrieval_retry_base_delay_sec=s3_retrieval_retry_base_delay_sec,
+                                     s3_retrieval_retry_max_delay_sec=s3_retrieval_retry_max_delay_sec)
 
     logger.info("registering storage area callbacks with Orthanc (RegisterStorageArea3)")
     logger.debug("calling orthanc.RegisterStorageArea3()")
@@ -376,7 +405,10 @@ def register_s3_zip_storage_plugin():
                 region=s3_zip_config.get("Region"),
                 temp_folder=s3_temp_folder_root,
                 compression=enable_compression,
-                key_prefix=key_prefix or "<none>")
+                key_prefix=key_prefix or "<none>",
+                s3_retrieval_max_attempts=s3_retrieval_max_attempts,
+                s3_retrieval_retry_base_delay_sec=s3_retrieval_retry_base_delay_sec,
+                s3_retrieval_retry_max_delay_sec=s3_retrieval_retry_max_delay_sec)
 
     # Failsafe: bypass logging framework entirely so this is always visible
     print(f"[s3zip] storage plugin registered | bucket={bucket_name} "

--- a/docker/python-s3-zip/pyproject.toml
+++ b/docker/python-s3-zip/pyproject.toml
@@ -9,3 +9,8 @@ dependencies = [
     "orthanc-tools>=0.17.17",
     "python-on-whales>=0.80.0",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]

--- a/docker/python-s3-zip/tests/test_scenario.py
+++ b/docker/python-s3-zip/tests/test_scenario.py
@@ -25,7 +25,7 @@ ANSI_COLORS = [
 ]
 ANSI_RESET = '\033[0m'
 
-compose_dir = os.path.dirname(os.path.abspath(__file__))
+compose_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 docker = DockerClient(compose_project_directory=compose_dir)
 
 _log_thread = None

--- a/docker/python-s3-zip/tests/test_threading_guards.py
+++ b/docker/python-s3-zip/tests/test_threading_guards.py
@@ -180,6 +180,121 @@ class FolderLeaseTests(unittest.TestCase):
                 storage._update_local_storage_stats()
             self.assertFalse(storage._scan_in_progress)
 
+    def test_folder_marker_critical_section_serializes_same_folder(self):
+        # Two threads asking for the SAME folder's CS must serialize. Two
+        # threads asking for DIFFERENT folders must run in parallel.
+        with tempfile.TemporaryDirectory() as root:
+            with mock.patch("local_storage.subprocess.run", side_effect=_fake_du_for(root)):
+                storage = LocalStorage(root=root, max_size_mb=1)
+
+            inside_same = threading.Event()
+            release_same = threading.Event()
+            second_acquired_same = threading.Event()
+
+            def first_same():
+                with storage.folder_marker_critical_section("series"):
+                    inside_same.set()
+                    self.assertTrue(release_same.wait(timeout=2))
+
+            def second_same():
+                self.assertTrue(inside_same.wait(timeout=2))
+                # Should block until release_same fires.
+                with storage.folder_marker_critical_section("series"):
+                    second_acquired_same.set()
+
+            t1 = threading.Thread(target=first_same)
+            t2 = threading.Thread(target=second_same)
+            t1.start(); t2.start()
+            self.assertTrue(inside_same.wait(timeout=2))
+            self.assertFalse(
+                second_acquired_same.wait(timeout=0.1),
+                "second caller for same folder must wait while first holds the section",
+            )
+            release_same.set()
+            t1.join(timeout=2); t2.join(timeout=2)
+            self.assertTrue(second_acquired_same.is_set())
+            self.assertEqual(storage._folder_marker_cs_locks, {})
+
+            # Different folder: must NOT block.
+            inside_a = threading.Event()
+            release_a = threading.Event()
+            inside_b = threading.Event()
+
+            def folder_a():
+                with storage.folder_marker_critical_section("a"):
+                    inside_a.set()
+                    self.assertTrue(release_a.wait(timeout=2))
+
+            def folder_b():
+                self.assertTrue(inside_a.wait(timeout=2))
+                with storage.folder_marker_critical_section("b"):
+                    inside_b.set()
+
+            ta = threading.Thread(target=folder_a)
+            tb = threading.Thread(target=folder_b)
+            ta.start(); tb.start()
+            self.assertTrue(
+                inside_b.wait(timeout=2),
+                "different-folder caller must not be blocked by holder of another folder",
+            )
+            release_a.set()
+            ta.join(timeout=2); tb.join(timeout=2)
+            self.assertEqual(storage._folder_marker_cs_locks, {})
+
+    def test_marker_critical_section_prevents_stale_marker_in_race_window(self):
+        # The classic interleaving the mutex is here to forbid:
+        #   copy:   takes CS, runs recheck (snapshot match) -> writes marker
+        #   create: takes CS afterwards, deletes marker
+        # End state must be NO marker. Without the mutex, create's invalidate
+        # could land between copy's recheck and copy's marker write, leaving
+        # a stale marker that hides an un-uploaded file.
+        with tempfile.TemporaryDirectory() as root:
+            with mock.patch("local_storage.subprocess.run", side_effect=_fake_du_for(root)):
+                storage = LocalStorage(root=root, max_size_mb=1)
+
+            folder = os.path.join(root, "series")
+            os.makedirs(folder)
+            marker_path = os.path.join(folder, ".s3-uploaded")
+
+            copy_inside_cs = threading.Event()
+            copy_finished_recheck = threading.Event()
+            create_done = threading.Event()
+
+            def copy_side():
+                with storage.folder_marker_critical_section("series"):
+                    copy_inside_cs.set()
+                    # Let create_side try (and block) before we publish.
+                    time.sleep(0.05)
+                    copy_finished_recheck.set()
+                    with open(marker_path, "w") as f:
+                        _ = f.write("series.zip")
+
+            def create_side():
+                self.assertTrue(copy_inside_cs.wait(timeout=2))
+                # This must block on the mutex until copy_side releases.
+                with storage.folder_marker_critical_section("series"):
+                    self.assertTrue(
+                        copy_finished_recheck.is_set(),
+                        "create entered CS before copy finished its recheck-and-publish window",
+                    )
+                    try:
+                        os.remove(marker_path)
+                    except FileNotFoundError:
+                        pass
+                    create_done.set()
+
+            t_copy = threading.Thread(target=copy_side)
+            t_create = threading.Thread(target=create_side)
+            t_copy.start(); t_create.start()
+            t_copy.join(timeout=2); t_create.join(timeout=2)
+
+            self.assertTrue(create_done.is_set())
+            self.assertFalse(
+                os.path.exists(marker_path),
+                "create's invalidate must win the end state; mutex orders the two",
+            )
+            self.assertEqual(storage._folder_marker_cs_locks, {})
+
     def test_remove_swallows_filenotfound_race_with_eviction(self):
         # Eviction can rmtree the parent folder between `os.path.exists` and
         # `os.remove`. The remove path must absorb that race instead of letting
@@ -588,6 +703,8 @@ class _CopyLocalStorage:
         self.root = root
         self.lease_depth = 0
         self.max_lease_depth = 0
+        self.marker_cs_depth = 0
+        self.max_marker_cs_depth = 0
         self.reads = []
 
     @contextmanager
@@ -598,6 +715,15 @@ class _CopyLocalStorage:
             yield
         finally:
             self.lease_depth -= 1
+
+    @contextmanager
+    def folder_marker_critical_section(self, local_series_folder):
+        self.marker_cs_depth += 1
+        self.max_marker_cs_depth = max(self.max_marker_cs_depth, self.marker_cs_depth)
+        try:
+            yield
+        finally:
+            self.marker_cs_depth -= 1
 
     def read_file(self, uuid, local_series_folder):
         if self.lease_depth <= 0:

--- a/docker/python-s3-zip/tests/test_threading_guards.py
+++ b/docker/python-s3-zip/tests/test_threading_guards.py
@@ -1,0 +1,248 @@
+import os
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+import zipfile
+from contextlib import contextmanager
+from pathlib import Path
+from unittest import mock
+
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1] / "plugin"
+sys.path.insert(0, str(PLUGIN_DIR))
+
+
+class _ContentType:
+    DICOM = 1
+    DICOM_UNTIL_PIXEL_DATA = 3
+
+
+class _ErrorCode:
+    SUCCESS = "SUCCESS"
+    UNKNOWN_RESOURCE = "UNKNOWN_RESOURCE"
+    PLUGIN = "PLUGIN"
+
+
+class _CompressionType:
+    NONE = 0
+
+
+class _DicomInstance:
+    pass
+
+
+orthanc_stub = types.SimpleNamespace(
+    ContentType=_ContentType,
+    ErrorCode=_ErrorCode,
+    CompressionType=_CompressionType,
+    DicomInstance=_DicomInstance,
+    LogInfo=lambda message: None,
+    SetCurrentThreadName=lambda name: None,
+)
+sys.modules.setdefault("orthanc", orthanc_stub)
+sys.modules.setdefault("boto3", types.SimpleNamespace(client=object))
+
+
+from custom_data import CustomData
+from local_storage import LocalStorage
+from local_to_s3_zip_manager import LocalToS3ZipManager
+from s3_zip_storage import S3ZipStorage
+
+
+def _fake_du_for(root: str, folder_name: str = "series", folder_size: int = 10):
+    def fake_run(cmd, capture_output, text, check):
+        folder = os.path.join(root, folder_name)
+        total_size = folder_size if os.path.isdir(folder) else 0
+        lines = []
+        if os.path.isdir(folder):
+            lines.append(f"{folder_size}\t{folder}")
+        lines.append(f"{total_size}\t{root}")
+        return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(lines), stderr="")
+
+    return fake_run
+
+
+class FolderLeaseTests(unittest.TestCase):
+    def test_leased_folder_is_skipped_by_eviction_then_evicted_after_release(self):
+        with tempfile.TemporaryDirectory() as root:
+            folder = os.path.join(root, "series")
+            os.makedirs(folder)
+            with open(os.path.join(folder, "instance"), "wb") as f:
+                f.write(b"abc")
+            with open(os.path.join(folder, ".s3-uploaded"), "w") as f:
+                f.write("series.zip")
+
+            with mock.patch("local_storage.subprocess.run", side_effect=_fake_du_for(root)):
+                storage = LocalStorage(root=root, max_size_mb=1)
+                storage.set_eviction_guard(lambda folder_name: True)
+
+                with storage.lease_folder("series"):
+                    result = storage.evict_all_safe()
+                    self.assertEqual(result.freed_folders, 0)
+                    self.assertEqual(result.skipped_folders, 1)
+                    self.assertTrue(os.path.isdir(folder))
+
+                result = storage.evict_all_safe()
+                self.assertEqual(result.freed_folders, 1)
+                self.assertFalse(os.path.exists(folder))
+
+    def test_make_room_rolls_back_reservation_when_slow_path_fails(self):
+        with tempfile.TemporaryDirectory() as root:
+            with mock.patch("local_storage.subprocess.run", side_effect=_fake_du_for(root)):
+                storage = LocalStorage(root=root, max_size_mb=0)
+
+            storage._available_size = 0
+            storage._reserved_bytes = 0
+
+            with mock.patch.object(
+                storage,
+                "_update_local_storage_stats_with_writes_paused",
+                side_effect=RuntimeError("scan failed"),
+            ):
+                with self.assertRaises(RuntimeError):
+                    storage._make_room(10)
+
+            self.assertEqual(storage._reserved_bytes, 0)
+            self.assertEqual(storage._available_size, 0)
+            self.assertFalse(storage._scan_in_progress)
+
+
+class _ReadPathLocalStorage:
+    def __init__(self):
+        self.lease_depth = 0
+        self.read_saw_lease = False
+
+    @contextmanager
+    def lease_folder(self, local_series_folder):
+        self.lease_depth += 1
+        try:
+            yield
+        finally:
+            self.lease_depth -= 1
+
+    def has_local_file(self, uuid, local_series_folder, content_type):
+        if self.lease_depth <= 0:
+            raise AssertionError("has_local_file called without a folder lease")
+        return True
+
+    def read_range(self, uuid, local_series_folder, content_type, range_start, size):
+        if self.lease_depth <= 0:
+            raise AssertionError("read_range called without a folder lease")
+        self.read_saw_lease = True
+        return orthanc_stub.ErrorCode.SUCCESS, b"dicom"
+
+
+class _UnusedZipManager:
+    def retrieve_zip_from_s3(self, s3_zip_key, local_series_folder):
+        raise AssertionError("retrieve_zip_from_s3 should not be called for a local hit")
+
+
+class S3ZipStorageReadTests(unittest.TestCase):
+    def test_local_hit_keeps_folder_leased_from_check_through_read(self):
+        local_storage = _ReadPathLocalStorage()
+        storage = S3ZipStorage.__new__(S3ZipStorage)
+        storage._local_storage = local_storage
+        storage._zip_manager = _UnusedZipManager()
+
+        custom_data = CustomData(
+            storage=CustomData.Storage.S3_ZIP,
+            local_series_folder="series",
+            s3_zip_key="series.zip",
+        ).to_binary()
+
+        error_code, data = storage.storage_read_range(
+            uuid="instance",
+            content_type=orthanc_stub.ContentType.DICOM,
+            range_start=0,
+            size=0,
+            custom_data=custom_data,
+        )
+
+        self.assertEqual(error_code, orthanc_stub.ErrorCode.SUCCESS)
+        self.assertEqual(data, b"dicom")
+        self.assertTrue(local_storage.read_saw_lease)
+        self.assertEqual(local_storage.lease_depth, 0)
+
+
+class _RetrievalLocalStorage:
+    def __init__(self):
+        self.lease_depth = 0
+        self.max_lease_depth = 0
+        self.writes = []
+
+    @contextmanager
+    def lease_folder(self, local_series_folder):
+        self.lease_depth += 1
+        self.max_lease_depth = max(self.max_lease_depth, self.lease_depth)
+        try:
+            yield
+        finally:
+            self.lease_depth -= 1
+
+    def write_file(self, local_series_folder, uuid, content):
+        if self.lease_depth <= 0:
+            raise AssertionError("write_file called without a folder lease")
+        self.writes.append((local_series_folder, uuid, content))
+
+    def read_file(self, local_series_folder, uuid):
+        raise AssertionError("read_file is not used by retrieval")
+
+
+class _ZipS3Client:
+    def download_file(self, bucket_name, s3_zip_key, destination_path):
+        with zipfile.ZipFile(destination_path, "w") as zipf:
+            zipf.writestr("a", b"A")
+            zipf.writestr("b", b"B")
+
+
+class ZipRetrievalTests(unittest.TestCase):
+    def _new_manager(self, local_storage):
+        return LocalToS3ZipManager(
+            s3_client=_ZipS3Client(),
+            bucket_name="bucket",
+            local_storage=local_storage,
+            enable_compression=False,
+            uncommitted_series_handler=object(),
+        )
+
+    def test_retrieval_refcount_is_owned_by_manager_lock(self):
+        manager = self._new_manager(_RetrievalLocalStorage())
+
+        first, first_is_new = manager._acquire_zip_retrieval("series.zip")
+        second, second_is_new = manager._acquire_zip_retrieval("series.zip")
+
+        self.assertTrue(first_is_new)
+        self.assertFalse(second_is_new)
+        self.assertIs(first, second)
+        self.assertEqual(first._ref_count, 2)
+
+        manager._release_zip_retrieval(first)
+        self.assertIs(manager._s3_zip_retrievals["series.zip"], first)
+        self.assertEqual(first._ref_count, 1)
+
+        manager._release_zip_retrieval(second)
+        self.assertNotIn("series.zip", manager._s3_zip_retrievals)
+        self.assertEqual(first._ref_count, 0)
+
+    def test_retrieve_zip_from_s3_holds_folder_lease_while_extracting(self):
+        local_storage = _RetrievalLocalStorage()
+        manager = self._new_manager(local_storage)
+
+        manager.retrieve_zip_from_s3(
+            s3_zip_key="series.zip",
+            local_series_folder="series",
+        )
+
+        self.assertEqual(
+            local_storage.writes,
+            [("series", "a", b"A"), ("series", "b", b"B")],
+        )
+        self.assertGreaterEqual(local_storage.max_lease_depth, 1)
+        self.assertEqual(local_storage.lease_depth, 0)
+        self.assertEqual(manager._s3_zip_retrievals, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/python-s3-zip/tests/test_threading_guards.py
+++ b/docker/python-s3-zip/tests/test_threading_guards.py
@@ -67,6 +67,30 @@ def _fake_du_for(root: str, folder_name: str = "series", folder_size: int = 10):
     return fake_run
 
 
+def _fake_du_walk(root: str):
+    """Generic du substitute: walks ``root`` and sums real file sizes per child."""
+    def fake_run(cmd, capture_output, text, check):
+        lines = []
+        total = 0
+        if os.path.isdir(root):
+            for entry in os.listdir(root):
+                child = os.path.join(root, entry)
+                if not os.path.isdir(child):
+                    continue
+                size = 0
+                for dirpath, _dirnames, filenames in os.walk(child):
+                    for fname in filenames:
+                        try:
+                            size += os.path.getsize(os.path.join(dirpath, fname))
+                        except OSError:
+                            pass
+                lines.append(f"{size}\t{child}")
+                total += size
+        lines.append(f"{total}\t{root}")
+        return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(lines), stderr="")
+    return fake_run
+
+
 class FolderLeaseTests(unittest.TestCase):
     def test_leased_folder_is_skipped_by_eviction_then_evicted_after_release(self):
         with tempfile.TemporaryDirectory() as root:
@@ -128,6 +152,189 @@ class FolderLeaseTests(unittest.TestCase):
             self.assertEqual(result.freed_folders, 0)
             self.assertEqual(result.skipped_folders, 1)
             self.assertTrue(os.path.isdir(folder))
+
+    def test_pause_writes_for_scan_clears_flag_when_wait_is_interrupted(self):
+        # Regression: if `wait()` raises after `_scan_in_progress` is set, the
+        # flag must be cleared and waiters notified. Otherwise every future
+        # write/scan deadlocks at `_enter_write` / `_pause_writes_for_scan`.
+        with tempfile.TemporaryDirectory() as root:
+            with mock.patch("local_storage.subprocess.run", side_effect=_fake_du_for(root)):
+                storage = LocalStorage(root=root, max_size_mb=1)
+
+            # Make sure the active-writers wait loop is taken.
+            storage._active_writers = 1
+
+            with mock.patch.object(
+                storage._io_condition,
+                "wait",
+                side_effect=KeyboardInterrupt("simulated signal"),
+            ):
+                with self.assertRaises(KeyboardInterrupt):
+                    storage._pause_writes_for_scan()
+
+            self.assertFalse(storage._scan_in_progress)
+
+            # And a fresh scan can still acquire the slot afterwards.
+            storage._active_writers = 0
+            with mock.patch("local_storage.subprocess.run", side_effect=_fake_du_for(root)):
+                storage._update_local_storage_stats()
+            self.assertFalse(storage._scan_in_progress)
+
+    def test_remove_swallows_filenotfound_race_with_eviction(self):
+        # Eviction can rmtree the parent folder between `os.path.exists` and
+        # `os.remove`. The remove path must absorb that race instead of letting
+        # FileNotFoundError leak back to Orthanc's storage callback.
+        with tempfile.TemporaryDirectory() as root:
+            with mock.patch("local_storage.subprocess.run", side_effect=_fake_du_for(root)):
+                storage = LocalStorage(root=root, max_size_mb=1)
+
+            with mock.patch("local_storage.os.remove", side_effect=FileNotFoundError("gone")):
+                # Must not raise.
+                storage.remove(
+                    uuid="instance",
+                    local_series_folder="series",
+                    content_type=orthanc_stub.ContentType.DICOM,
+                )
+
+
+class ConcurrentStressTests(unittest.TestCase):
+    """Best-effort multi-thread stress.
+
+    Spins up a real ``LocalStorage`` against a real temp directory and runs
+    writers, readers, removers and evictors against it concurrently. Each
+    worker uses the public storage API just like Orthanc would. The asserts
+    only check global invariants -- no exceptions surface, accounting
+    stays consistent, and no scan slot or write count is left dangling.
+    """
+
+    def test_writers_readers_evictor_keep_state_consistent(self):
+        import random
+
+        with tempfile.TemporaryDirectory() as root:
+            with mock.patch("local_storage.subprocess.run", side_effect=_fake_du_walk(root)):
+                # Generous budget so the fast path is usually taken, but small
+                # enough that some calls cross the slow path during the run.
+                storage = LocalStorage(root=root, max_size_mb=4)
+
+                # Treat every folder as safe to evict so eviction actually fires.
+                storage.set_eviction_guard(lambda folder_name: True)
+
+                folders = [f"series-{i}" for i in range(6)]
+                stop = threading.Event()
+                errors: list[BaseException] = []
+                errors_lock = threading.Lock()
+
+                def record(exc: BaseException) -> None:
+                    with errors_lock:
+                        errors.append(exc)
+
+                def writer(seed: int) -> None:
+                    rng = random.Random(seed)
+                    with mock.patch("local_storage.subprocess.run", side_effect=_fake_du_walk(root)):
+                        for _ in range(60):
+                            if stop.is_set():
+                                return
+                            folder = rng.choice(folders)
+                            uuid = f"u-{rng.randint(0, 999)}-{seed}-{_}"
+                            content = os.urandom(rng.randint(64, 4096))
+                            try:
+                                storage.write_file(local_series_folder=folder, uuid=uuid, content=content)
+                            except Exception as e:
+                                record(e)
+                                return
+
+                def reader(seed: int) -> None:
+                    rng = random.Random(seed + 1000)
+                    for _ in range(80):
+                        if stop.is_set():
+                            return
+                        folder = rng.choice(folders)
+                        uuid = f"u-{rng.randint(0, 999)}-{seed}-{_}"
+                        try:
+                            with storage.lease_folder(folder):
+                                if storage.has_local_file(
+                                    uuid=uuid,
+                                    local_series_folder=folder,
+                                    content_type=orthanc_stub.ContentType.DICOM,
+                                ):
+                                    storage.read_file(uuid=uuid, local_series_folder=folder)
+                        except FileNotFoundError:
+                            # Acceptable: file was evicted/removed between
+                            # has_local_file and read; the lease only protects
+                            # the folder, not individual files post-eviction.
+                            pass
+                        except Exception as e:
+                            record(e)
+                            return
+
+                def remover(seed: int) -> None:
+                    rng = random.Random(seed + 2000)
+                    for _ in range(40):
+                        if stop.is_set():
+                            return
+                        folder = rng.choice(folders)
+                        uuid = f"u-{rng.randint(0, 999)}-{seed}-{_}"
+                        try:
+                            storage.remove(
+                                uuid=uuid,
+                                local_series_folder=folder,
+                                content_type=orthanc_stub.ContentType.DICOM,
+                            )
+                        except Exception as e:
+                            record(e)
+                            return
+
+                def evictor() -> None:
+                    with mock.patch("local_storage.subprocess.run", side_effect=_fake_du_walk(root)):
+                        for _ in range(15):
+                            if stop.is_set():
+                                return
+                            try:
+                                storage.evict_all_safe()
+                            except Exception as e:
+                                record(e)
+                                return
+
+                threads: list[threading.Thread] = []
+                for i in range(4):
+                    threads.append(threading.Thread(target=writer, args=(i,)))
+                for i in range(4):
+                    threads.append(threading.Thread(target=reader, args=(i,)))
+                for i in range(2):
+                    threads.append(threading.Thread(target=remover, args=(i,)))
+                threads.append(threading.Thread(target=evictor))
+
+                for t in threads:
+                    t.start()
+
+                deadline = time.monotonic() + 8
+                for t in threads:
+                    remaining = max(0.1, deadline - time.monotonic())
+                    t.join(timeout=remaining)
+                stop.set()
+
+                for t in threads:
+                    if t.is_alive():
+                        self.fail(f"thread did not finish in time: {t.name}")
+
+                if errors:
+                    self.fail(f"workers raised: {[type(e).__name__ + ': ' + str(e) for e in errors]}")
+
+                # Drain any final state with one more refresh so accounting
+                # reflects what is actually on disk.
+                with mock.patch("local_storage.subprocess.run", side_effect=_fake_du_walk(root)):
+                    storage._update_local_storage_stats()
+
+                # Global invariants after the storm.
+                self.assertEqual(storage._active_writers, 0)
+                self.assertFalse(storage._scan_in_progress)
+                self.assertEqual(storage._folder_lease_counts, {})
+                self.assertEqual(storage._reserved_bytes, 0)
+                # Available + apparent disk usage must equal max_size after
+                # a fresh rescan (no reservations leaked).
+                used_estimate = storage._max_size - storage._available_size
+                self.assertGreaterEqual(used_estimate, 0)
+                self.assertLessEqual(used_estimate, storage._max_size)
 
 
 class _ReadPathLocalStorage:
@@ -425,20 +632,23 @@ class _UncommittedHandler:
 
 
 class CopySeriesToS3Tests(unittest.TestCase):
+    def _make_manager(self, local_storage, s3_client=None, uncommitted_handler=None):
+        return LocalToS3ZipManager(
+            s3_client=s3_client or _UploadS3Client(),
+            bucket_name="bucket",
+            local_storage=local_storage,
+            enable_compression=False,
+            uncommitted_series_handler=uncommitted_handler or _UncommittedHandler(),
+            s3_retrieval_retry_base_delay_sec=0,
+            s3_retrieval_retry_max_delay_sec=0,
+        )
+
     def test_copy_series_to_s3_leases_source_folder_and_writes_marker_atomically(self):
         with tempfile.TemporaryDirectory() as root:
             local_storage = _CopyLocalStorage(root)
             s3_client = _UploadS3Client()
             uncommitted_handler = _UncommittedHandler()
-            manager = LocalToS3ZipManager(
-                s3_client=s3_client,
-                bucket_name="bucket",
-                local_storage=local_storage,
-                enable_compression=False,
-                uncommitted_series_handler=uncommitted_handler,
-                s3_retrieval_retry_base_delay_sec=0,
-                s3_retrieval_retry_max_delay_sec=0,
-            )
+            manager = self._make_manager(local_storage, s3_client, uncommitted_handler)
 
             custom_data = CustomData(
                 storage=CustomData.Storage.LOCAL,
@@ -465,6 +675,58 @@ class CopySeriesToS3Tests(unittest.TestCase):
             marker_path = os.path.join(root, "series", ".s3-uploaded")
             with open(marker_path, "r") as f:
                 self.assertEqual(f.read(), "orthanc-series.zip")
+
+    def test_copy_skips_marker_when_new_instance_arrives_during_copy(self):
+        # Recheck-before-marker: if a new attachment appears between the
+        # initial snapshot and the marker write, the uploaded zip is already
+        # incomplete and the marker must NOT be published. The next stable
+        # event will trigger a fresh copy that captures the new instance.
+        with tempfile.TemporaryDirectory() as root:
+            local_storage = _CopyLocalStorage(root)
+            uncommitted_handler = _UncommittedHandler()
+            manager = self._make_manager(local_storage, uncommitted_handler=uncommitted_handler)
+
+            custom_data = CustomData(
+                storage=CustomData.Storage.LOCAL,
+                local_series_folder="series",
+            )
+
+            # First call: initial snapshot. Second call (the recheck): a third
+            # attachment has appeared.
+            attachment_calls = [["a", "b"], ["a", "b", "c"]]
+
+            with mock.patch.object(manager, "_get_instances_attachments", side_effect=attachment_calls):
+                with mock.patch.object(CustomData, "from_orthanc_attachment", return_value=custom_data):
+                    manager.copy_series_to_s3("orthanc-series")
+
+            # Snapshot's instances were still uploaded + custom-data'd: the
+            # snapshot's own data is valid in S3. Only the marker is withheld.
+            self.assertEqual(local_storage.reads, [("a", "series"), ("b", "series")])
+            self.assertFalse(
+                os.path.exists(os.path.join(root, "series", ".s3-uploaded")),
+                "marker must not be written when attachment set changed during copy",
+            )
+            # We still commit -- the data we did upload is on S3 and the next
+            # stable-series event will re-fire copy_series_to_s3 to cover the
+            # new instance.
+            self.assertEqual(uncommitted_handler.committed, ["orthanc-series"])
+
+    def test_invalidate_s3_uploaded_marker_removes_existing_marker(self):
+        with tempfile.TemporaryDirectory() as root:
+            local_storage = _CopyLocalStorage(root)
+            manager = self._make_manager(local_storage)
+
+            folder = os.path.join(root, "series")
+            os.makedirs(folder)
+            marker_path = os.path.join(folder, ".s3-uploaded")
+            with open(marker_path, "w") as f:
+                _ = f.write("series.zip")
+
+            self.assertTrue(manager.invalidate_s3_uploaded_marker("series"))
+            self.assertFalse(os.path.exists(marker_path))
+
+            # Idempotent on missing marker.
+            self.assertFalse(manager.invalidate_s3_uploaded_marker("series"))
 
 
 if __name__ == "__main__":

--- a/docker/python-s3-zip/tests/test_threading_guards.py
+++ b/docker/python-s3-zip/tests/test_threading_guards.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 import types
 import unittest
 import zipfile
@@ -40,6 +42,7 @@ orthanc_stub = types.SimpleNamespace(
     DicomInstance=_DicomInstance,
     LogInfo=lambda message: None,
     SetCurrentThreadName=lambda name: None,
+    SetAttachmentCustomData=lambda uuid, custom_data: None,
 )
 sys.modules.setdefault("orthanc", orthanc_stub)
 sys.modules.setdefault("boto3", types.SimpleNamespace(client=object))
@@ -107,6 +110,24 @@ class FolderLeaseTests(unittest.TestCase):
             self.assertEqual(storage._reserved_bytes, 0)
             self.assertEqual(storage._available_size, 0)
             self.assertFalse(storage._scan_in_progress)
+
+    def test_eviction_keeps_folder_queued_when_delete_fails(self):
+        with tempfile.TemporaryDirectory() as root:
+            folder = os.path.join(root, "series")
+            os.makedirs(folder)
+            with open(os.path.join(folder, "instance"), "wb") as f:
+                f.write(b"abc")
+
+            with mock.patch("local_storage.subprocess.run", side_effect=_fake_du_for(root)):
+                storage = LocalStorage(root=root, max_size_mb=1)
+                storage.set_eviction_guard(lambda folder_name: True)
+
+                with mock.patch("local_storage.shutil.rmtree", side_effect=OSError("locked")):
+                    result = storage.evict_all_safe()
+
+            self.assertEqual(result.freed_folders, 0)
+            self.assertEqual(result.skipped_folders, 1)
+            self.assertTrue(os.path.isdir(folder))
 
 
 class _ReadPathLocalStorage:
@@ -197,14 +218,53 @@ class _ZipS3Client:
             zipf.writestr("b", b"B")
 
 
+class _FlakyZipS3Client:
+    def __init__(self, failures_before_success):
+        self.failures_before_success = failures_before_success
+        self.download_attempts = 0
+
+    def download_file(self, bucket_name, s3_zip_key, destination_path):
+        self.download_attempts += 1
+        if self.download_attempts <= self.failures_before_success:
+            raise ConnectionError("temporary S3 connection glitch")
+        with zipfile.ZipFile(destination_path, "w") as zipf:
+            zipf.writestr("a", b"A")
+
+
+class _BadZipS3Client:
+    def __init__(self):
+        self.download_attempts = 0
+
+    def download_file(self, bucket_name, s3_zip_key, destination_path):
+        self.download_attempts += 1
+        with open(destination_path, "wb") as f:
+            f.write(b"this is not a zip")
+
+
+class _BlockingFailS3Client:
+    def __init__(self):
+        self.download_started = threading.Event()
+        self.release_failure = threading.Event()
+        self.download_attempts = 0
+
+    def download_file(self, bucket_name, s3_zip_key, destination_path):
+        self.download_attempts += 1
+        self.download_started.set()
+        self.release_failure.wait(timeout=5)
+        raise ConnectionError("shared retrieval failure")
+
+
 class ZipRetrievalTests(unittest.TestCase):
-    def _new_manager(self, local_storage):
+    def _new_manager(self, local_storage, s3_client=None, max_attempts=3):
         return LocalToS3ZipManager(
-            s3_client=_ZipS3Client(),
+            s3_client=s3_client or _ZipS3Client(),
             bucket_name="bucket",
             local_storage=local_storage,
             enable_compression=False,
             uncommitted_series_handler=object(),
+            s3_retrieval_max_attempts=max_attempts,
+            s3_retrieval_retry_base_delay_sec=0,
+            s3_retrieval_retry_max_delay_sec=0,
         )
 
     def test_retrieval_refcount_is_owned_by_manager_lock(self):
@@ -242,6 +302,169 @@ class ZipRetrievalTests(unittest.TestCase):
         self.assertGreaterEqual(local_storage.max_lease_depth, 1)
         self.assertEqual(local_storage.lease_depth, 0)
         self.assertEqual(manager._s3_zip_retrievals, {})
+
+    def test_retrieve_zip_from_s3_retries_transient_download_failure(self):
+        local_storage = _RetrievalLocalStorage()
+        s3_client = _FlakyZipS3Client(failures_before_success=2)
+        manager = self._new_manager(local_storage, s3_client=s3_client, max_attempts=3)
+
+        manager.retrieve_zip_from_s3(
+            s3_zip_key="series.zip",
+            local_series_folder="series",
+        )
+
+        self.assertEqual(s3_client.download_attempts, 3)
+        self.assertEqual(local_storage.writes, [("series", "a", b"A")])
+        self.assertEqual(manager._s3_zip_retrievals, {})
+
+    def test_retrieve_zip_from_s3_does_not_retry_bad_zip(self):
+        local_storage = _RetrievalLocalStorage()
+        s3_client = _BadZipS3Client()
+        manager = self._new_manager(local_storage, s3_client=s3_client, max_attempts=3)
+
+        with self.assertRaises(zipfile.BadZipFile):
+            manager.retrieve_zip_from_s3(
+                s3_zip_key="series.zip",
+                local_series_folder="series",
+            )
+
+        self.assertEqual(s3_client.download_attempts, 1)
+        self.assertEqual(local_storage.writes, [])
+        self.assertEqual(manager._s3_zip_retrievals, {})
+
+    def test_waiting_retrieval_callers_share_terminal_failure(self):
+        local_storage = _RetrievalLocalStorage()
+        s3_client = _BlockingFailS3Client()
+        manager = self._new_manager(local_storage, s3_client=s3_client, max_attempts=1)
+        errors = []
+
+        def retrieve():
+            try:
+                manager.retrieve_zip_from_s3(
+                    s3_zip_key="series.zip",
+                    local_series_folder="series",
+                )
+            except Exception as e:
+                errors.append(e)
+
+        first = threading.Thread(target=retrieve)
+        second = threading.Thread(target=retrieve)
+        first.start()
+        self.assertTrue(s3_client.download_started.wait(timeout=5))
+        second.start()
+
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            with manager._s3_zip_retrievals_lock:
+                retrieval = manager._s3_zip_retrievals.get("series.zip")
+                ref_count = retrieval._ref_count if retrieval is not None else 0
+            if ref_count >= 2:
+                break
+            time.sleep(0.01)
+        else:
+            self.fail("second retrieval caller did not acquire the shared ZipRetrieval")
+
+        s3_client.release_failure.set()
+        first.join(timeout=5)
+        second.join(timeout=5)
+
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        self.assertEqual(len(errors), 2)
+        self.assertTrue(all(isinstance(e, ConnectionError) for e in errors))
+        self.assertEqual(s3_client.download_attempts, 1)
+        self.assertEqual(manager._s3_zip_retrievals, {})
+
+
+class _CopyLocalStorage:
+    def __init__(self, root):
+        self.root = root
+        self.lease_depth = 0
+        self.max_lease_depth = 0
+        self.reads = []
+
+    @contextmanager
+    def lease_folder(self, local_series_folder):
+        self.lease_depth += 1
+        self.max_lease_depth = max(self.max_lease_depth, self.lease_depth)
+        try:
+            yield
+        finally:
+            self.lease_depth -= 1
+
+    def read_file(self, uuid, local_series_folder):
+        if self.lease_depth <= 0:
+            raise AssertionError("read_file called without a folder lease")
+        self.reads.append((uuid, local_series_folder))
+        return f"content-{uuid}".encode("ascii")
+
+    def write_file(self, local_series_folder, uuid, content):
+        raise AssertionError("write_file is not used by copy_series_to_s3")
+
+    def get_folder_path(self, local_series_folder):
+        return os.path.join(self.root, local_series_folder)
+
+
+class _UploadS3Client:
+    def __init__(self):
+        self.uploads = []
+        self.uploaded_zip_entries = []
+
+    def upload_file(self, source_path, bucket_name, s3_key):
+        self.uploads.append((bucket_name, s3_key))
+        with zipfile.ZipFile(source_path, "r") as zipf:
+            self.uploaded_zip_entries = sorted(zipf.namelist())
+
+
+class _UncommittedHandler:
+    def __init__(self):
+        self.committed = []
+
+    def on_committed_series(self, series_id):
+        self.committed.append(series_id)
+
+
+class CopySeriesToS3Tests(unittest.TestCase):
+    def test_copy_series_to_s3_leases_source_folder_and_writes_marker_atomically(self):
+        with tempfile.TemporaryDirectory() as root:
+            local_storage = _CopyLocalStorage(root)
+            s3_client = _UploadS3Client()
+            uncommitted_handler = _UncommittedHandler()
+            manager = LocalToS3ZipManager(
+                s3_client=s3_client,
+                bucket_name="bucket",
+                local_storage=local_storage,
+                enable_compression=False,
+                uncommitted_series_handler=uncommitted_handler,
+                s3_retrieval_retry_base_delay_sec=0,
+                s3_retrieval_retry_max_delay_sec=0,
+            )
+
+            custom_data = CustomData(
+                storage=CustomData.Storage.LOCAL,
+                local_series_folder="series",
+            )
+            set_custom_data_calls = []
+
+            with mock.patch.object(manager, "_get_instances_attachments", return_value=["a", "b"]):
+                with mock.patch.object(CustomData, "from_orthanc_attachment", return_value=custom_data):
+                    with mock.patch.object(
+                        orthanc_stub,
+                        "SetAttachmentCustomData",
+                        side_effect=lambda uuid, data: set_custom_data_calls.append((uuid, data)),
+                    ):
+                        manager.copy_series_to_s3("orthanc-series")
+
+            self.assertEqual(local_storage.reads, [("a", "series"), ("b", "series")])
+            self.assertGreaterEqual(local_storage.max_lease_depth, 1)
+            self.assertEqual(local_storage.lease_depth, 0)
+            self.assertEqual(s3_client.uploads, [("bucket", "orthanc-series.zip")])
+            self.assertEqual(s3_client.uploaded_zip_entries, ["a", "b"])
+            self.assertEqual([uuid for uuid, _ in set_custom_data_calls], ["a", "b"])
+            self.assertEqual(uncommitted_handler.committed, ["orthanc-series"])
+            marker_path = os.path.join(root, "series", ".s3-uploaded")
+            with open(marker_path, "r") as f:
+                self.assertEqual(f.read(), "orthanc-series.zip")
 
 
 if __name__ == "__main__":

--- a/docker/python-s3-zip/uv.lock
+++ b/docker/python-s3-zip/uv.lock
@@ -251,6 +251,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -335,6 +344,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "inquirer"
 version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -413,6 +431,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "paramiko"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -434,6 +461,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/db/db/d4102f356af18f316c67f2cead8ece307f731dd63140e2c71f170ddacf9b/pika-1.3.2.tar.gz", hash = "sha256:b2a327ddddf8570b4965b3576ac77091b850262d34ce8c1d8cb4e4146aa4145f", size = 145029, upload-time = "2023-05-05T14:25:43.368Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/f3/f412836ec714d36f0f4ab581b84c491e3f42c6b5b97a6c6ed1817f3c16d0/pika-1.3.2-py3-none-any.whl", hash = "sha256:0779a7c1fafd805672796085560d290213a465e4f6f76a6fb19e378d8041a14f", size = 155415, upload-time = "2023-05-05T14:25:41.484Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -541,6 +577,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -573,6 +618,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
     { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
     { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -610,12 +671,20 @@ dependencies = [
     { name = "python-on-whales" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.42.54" },
     { name = "orthanc-tools", specifier = ">=0.17.17" },
     { name = "python-on-whales", specifier = ">=0.80.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "readchar"


### PR DESCRIPTION
**Not to be merged yet: tests underway**

## Fix race condition in available size measurement

This fixes the race condition that led to the available size being sometimes reported as negative.

This is the scenario that is now fixed:

```
Thread 1: _make_room(500 MB)  → fast path, _available_size: 1024 → 524 MB, lock released
Thread 2: _make_room(400 MB)  → fast path, _available_size: 524  → 124 MB, lock released
Thread 3: _make_room(200 MB)  → fast path FAILS (124 < 200)
          → slow path: _update_local_storage_stats() rescans disk with du -b
          → THREADS 1 & 2 HAVEN'T WRITTEN YET → du -b sees old disk state
          → _available_size = max_size - old_disk_usage  ← BLOWS AWAY both reservations
          → space looks fine, fast path proceeds
Thread 1: writes 500 MB to disk  (outside lock)
Thread 2: writes 400 MB to disk  (outside lock)
Thread 3: writes 200 MB to disk  (outside lock)
Total written: 1100 MB > 1024 MB max
Next slow-path scan: _available_size = 1024 MB - 1100 MB = -76 MB  ← NEGATIVE
```

Fixing this required pausing writes when folder usage scan is underway and, conversely, wait for writes to finish before scanning.

## Fixed: `ZipRetrieval` can double-delete or delete the wrong active retrieval
`docker/python-s3-zip/plugin/local_to_s3_zip_manager.py:52-71`, `333-357`

### Problem
The manager gets a `ZipRetrieval` from `_s3_zip_retrievals` under the dict lock, but the refcount is incremented later, outside that lock. That leaves a stale-object window.

Repro:

1. Thread 1: calls `retrieve_zip_from_s3("series.zip")`, creates `ZipRetrieval R1`, enters it, `_ref_count = 1`, starts download.
2. Thread 2: enters `retrieve_zip_from_s3`, takes `_s3_zip_retrievals_lock`, reads `R1` from the dict, releases the lock.
3. Thread 2: before `with zip_retrieval:` increments `_ref_count`, it is preempted.
4. Thread 1: finishes, exits `R1`, decrements `_ref_count` to `0`, deletes `_s3_zip_retrievals["series.zip"]`.
5. Thread 2: resumes with stale `R1`, enters/exits it, and calls `_discard_zip_retrieval()` again.
6. Result A: if no new retrieval was created, `del self._s3_zip_retrievals[series_id]` raises `KeyError`.
7. Result B: if Thread 3 created `R2` for the same key meanwhile, Thread 2 deletes `R2` while Thread 3 is still downloading, allowing duplicate concurrent extractions.

Fix: increment/acquire the retrieval reference while holding `_s3_zip_retrievals_lock`, and discard by identity, e.g. delete only if `dict.get(key) is retrieval`.

### Fix: Proper ZipRetrieval ownership
- Move retrieval ref acquisition/release into LocalToS3ZipManager under `_s3_zip_retrievals_lock`.
- Stop letting ZipRetrieval.`__exit__()` unconditionally delete from the manager dict.
- Delete only if the dict still points to the same retrieval object, e.g. if `self._s3_zip_retrievals.get(key) is retrieval`.
- Add a deterministic test for the stale-reference scenario.

## Fixed: eviction can race between `has_local_file()` and `read_range()`
`docker/python-s3-zip/plugin/s3_zip_storage.py:158-199`, `docker/python-s3-zip/plugin/local_storage.py:414-431`, `623-639`

### Problem
Reads do not participate in the eviction protocol. Writes are paused during scans, but reads can observe a file and then lose it before opening.

Repro:

1. Thread 1: `storage_read_range()` checks `has_local_file()` and gets `True`.
2. Thread 2: `_make_room()` slow path or `evict_all_safe()` pauses writes, scans the cache, sees `.s3-uploaded`, and evicts the folder with `shutil.rmtree()`.
3. Thread 1: continues to `local_storage.read_range()`.
4. Thread 1: `open(path, "rb")` raises `FileNotFoundError`.
5. Result: the request returns `UNKNOWN_RESOURCE` even though the object is S3-backed and recoverable, because the S3 retrieval branch was skipped based on the stale `has_local_file()` result.

Fix: add a local-file lease/refcount used by eviction, or retry through S3 when `read_range()` loses a supposedly local cached file for S3-backed custom data.

### Fix : add folder leases to local storage.
- Add a small context manager like lease\_folder(local\_series\_folder).
- Track active lease counts per folder in LocalStorage.
- Make \_evict\_until() skip leased folders exactly like it skips folders that are not safe to evict.
- Use this to protect local reads across the whole has\_local\_file() plus read\_range() window.

More details: the lease needs to start before has_local_file() and stay held until after read_range() finishes.

The important guarantee is:

- *Thread 1* acquires lease for series-folder.
- *Thread 1* calls has_local_file() and sees True.
- *Thread 2* starts eviction.
- *Thread 2* sees series-folder has an active lease and skips it.
- *Thread 1* calls read_range() while still leased.
- *Thread 1* releases lease only after the file read is done.

So eviction can still scan globally, but it cannot delete that folder in the check-then-read window.

A lease around the whole extraction covers the partially-extracted-folder case too (see bewlow)
The lease should be tracked by folder name, not by file path, because eviction deletes 
whole series folders.

## Fixed: eviction can delete a folder during zip extraction
`docker/python-s3-zip/plugin/local_to_s3_zip_manager.py:302-310`, `415-421`; `docker/python-s3-zip/plugin/local_storage.py:235-261`

### Problem
`retrieve_zip_from_s3()` writes one file at a time. The new write pause only protects each individual file write, not the whole series extraction. If the target folder already has `.s3-uploaded`, eviction can treat a partially extracted folder as safe.

**Repro:**
1. Precondition: local series folder exists with `.s3-uploaded`, but one attachment is missing, so a read triggers S3 retrieval.
2. Thread 1: starts `_retrieve_zip_from_s3()` and writes file A.
3. Thread 1: returns from `write_file()` for file A. `_active_writers` is now `0`; marker still exists.
4. Thread 2: eviction scan starts, guard sees `.s3-uploaded`, deletes the whole folder.
5. Thread 1: continues extraction, writes file B, file C, etc., recreating the folder.
6. Thread 1: marks retrieval downloaded.
7. Thread 3: asks for file A and gets a miss, even though the retrieval was reported complete.

Fix: protect an entire series folder during retrieval/extraction, remove or ignore stale markers during extraction, or extract into a temp folder and atomically swap once complete.

### Fix: Protect whole-series S3 retrieval/extraction.
- Wrap `_retrieve_zip_from_s3(..., local_series_folder)` in a folder lease for the full extraction loop, not just each `write_file()`.
- This prevents eviction from deleting a partially extracted folder if an old `.s3-uploaded` marker is present.
- I'll likely also make marker handling explicit in comments, because after a successful retrieval the folder is safe to evict, but during extraction it is not.

## Fixed: `_make_room()` leaks reservations if the slow path raises
`docker/python-s3-zip/plugin/local_storage.py:287-366`, rollback only at `485-488`

### Problem
`_make_room()` mutates `_available_size` and `_reserved_bytes` before doing 
`du`, `getmtime`, and `shutil.rmtree()`. If any slow-path operation raises 
before `_make_room()` returns, `write_file()` never receives `reserved_bytes`, 
so it cannot rollback.

**Repro:**
1. Thread 1: calls `write_file()`.
2. Thread 1: `_make_room()` subtracts `reservation_size` and increments `_reserved_bytes`.
3. Thread 1: enters slow path.
4. Thread 2 or the environment changes the filesystem, or `shutil.rmtree()`/`du`/`getmtime()` fails.
5. Thread 1: exception escapes `_make_room()`.
6. Result: `_reserved_bytes` remains too high and `_available_size` remains too low forever, causing excessive eviction and misleading cache stats.

### Fix: Roll back reservations if `_make_room()` fails before returning.

Make `_make_room()` rollback its own reservation in an `except` block until it successfully returns ownership of the reservation to `write_file()`.
- Wrap the slow path after reservation in `try/except`.
- If `du`, `getmtime`, eviction, or any other slow-path operation raises, call `_rollback_write_reservation(reservation_size)` before re-raising.
- Add a test that forces the slow path to fail and asserts `_reserved_bytes`/`_available_size` are restored.


## A few focused tests.
- `ZipRetrieval` stale-object/double-discard test.
- leased folder is skipped by eviction, then evicted after lease release.
- read/check lease prevents eviction between `has_local_file()` and `read_range()`.
- retrieval extraction holds a folder lease.
- `_make_room()` exception rollback.

## Hardening S3 operations




